### PR TITLE
Ignore attributes potentially containing JSON/HTML

### DIFF
--- a/src/getAttributes.js
+++ b/src/getAttributes.js
@@ -11,7 +11,8 @@ export function getAttributes( el, attributesToIgnore = ['id', 'class', 'length'
 
   return attrs.reduce( ( sum, next ) =>
   {
-    if ( ! ( attributesToIgnore.indexOf( next.nodeName ) > -1 ) )
+    if ( ! ( attributesToIgnore.indexOf( next.nodeName ) > -1 ) 
+        && !(next.value && (next.value.indexOf('{') > -1 || next.value.indexOf('<') > -1)))
     {
       sum.push( `[${next.nodeName}="${next.value}"]` );
     }


### PR DESCRIPTION
Some websites have the habit of putting HTML/JSON in data attributes, causing the unique-selector builder to generate invalid querySelectors. This commit adds a fairly naive check to skip these attributes.

For performance reasons, I didn't want to go full-blown regex validation.