### PR TITLE
add double quotes to data selector values

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cypress/unique-selector",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@cypress/unique-selector",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cypress/unique-selector",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "description": "Given a DOM node, return a unique CSS selector matching only that element",
   "main": "./lib/index.js",
   "jsnext:main": "./src/index.js",

--- a/src/getData.js
+++ b/src/getData.js
@@ -1,5 +1,3 @@
-import 'css.escape';
-
 /**
  * Returns the data-{dataAttr} selector of the element wrapped in double quotes.
  * @param  { String } selectorType - The type of selector to return.

--- a/src/getData.js
+++ b/src/getData.js
@@ -1,24 +1,29 @@
 /**
- * Returns the data-{dataAttr} selector of the element wrapped in double quotes.
+ * Returns the data-{dataAttr} selector of the element
  * @param  { String } selectorType - The type of selector to return.
- * @return { String } - The data-{dataAttr} selector of the element wrapped in double quotes.
+ * @param  { String } attributes - The attributes of the element.
+ * @return { String | null } - The data-{dataAttr} selector of the element.
  */
 
-export const getData = ( selectorType, attributes ) => {
-  for ( let i = 0; i < attributes.length; i++ ) {
+export const getData = ( selectorType, attributes ) =>
+{
+  for ( let i = 0; i < attributes.length; i++ )
+  {
     // extract node name + value
     const { nodeName, value } = attributes[ i ];
 
     // if this matches our selector
-    if ( nodeName === selectorType ){
-      if ( value ) {
-      // if we have value that needs quotes
-      return `[${nodeName}="${value}"]`;
+    if ( nodeName === selectorType )
+    {
+      if ( value )
+      {
+        // if we have value that needs quotes
+        return `[${nodeName}="${value}"]`;
       }
 
       return `[${nodeName}]`;
     }
   }
- 
-   return null;
- };
+
+  return null;
+};

--- a/src/getData.js
+++ b/src/getData.js
@@ -16,6 +16,25 @@ function needsQuote( v )
   return v !== CSS.escape( v );
 }
 
+/**
+  * Method to wrap the HTML attribute selector text in double quotes if there's missing
+  * @param {string} selector -> a string that represents a HTML attribute selector
+  * @returns {string} -> the selector wrapped in double quotes if needed
+  */
+const _setQuotesToAttrSelector = (selector) => {
+  const [attributeName, attributeValue] = selector.split('=')
+
+  if (attributeName && attributeValue) {
+    const hasQuotes = (attributeValue[0] === '"' || attributeValue[0] === '\'')
+
+    if (selector.split('').includes('[', ']') && !hasQuotes) {
+      return `[${attributeName.replace('[', '')}="${attributeValue.replace(']', '"]')}`
+    }
+}
+
+  return selector
+}
+
 export const getData = ( selectorType, attributes ) =>
 {
   for ( let i = 0; i < attributes.length; i++ )
@@ -31,13 +50,13 @@ export const getData = ( selectorType, attributes ) =>
         if ( needsQuote( value ) )
         {
           // if we have value that needs quotes
-          return `[${nodeName}="${value}"]`;
+          return _setQuotesToAttrSelector(`[${nodeName}="${value}"]`);
         }
 
-        return `[${nodeName}=${value}]`;
+        return _setQuotesToAttrSelector(`[${nodeName}=${value}]`);
       }
 
-      return `[${nodeName}]`;
+      return _setQuotesToAttrSelector(`[${nodeName}]`);
     }
   }
 

--- a/src/getData.js
+++ b/src/getData.js
@@ -1,16 +1,26 @@
+import 'css.escape';
+
 /**
  * Returns the data-{dataAttr} selector of the element wrapped in double quotes.
- * @param  { String } selectorType
- * @return { Function }
- * @param  { Object } element
- * @return { String }
+ * @param  { String } selectorType - The type of selector to return.
+ * @return { String } - The data-{dataAttr} selector of the element wrapped in double quotes.
  */
+
 export const getData = ( selectorType, attributes ) => {
   for ( let i = 0; i < attributes.length; i++ ) {
-    const { nodeName, value } = attributes[ i ]
+    // extract node name + value
+    const { nodeName, value } = attributes[ i ];
 
-    if ( nodeName === selectorType ) return `[${nodeName}="${value}"]`
+    // if this matches our selector
+    if ( nodeName === selectorType ){
+      if ( value ) {
+      // if we have value that needs quotes
+      return `[${nodeName}="${value}"]`;
+      }
+
+      return `[${nodeName}]`;
+    }
   }
-
-  return null
-}
+ 
+   return null;
+ };

--- a/src/getData.js
+++ b/src/getData.js
@@ -1,64 +1,16 @@
-import 'css.escape';
-
 /**
- * Returns the data-{dataAttr} selector of the element
+ * Returns the data-{dataAttr} selector of the element wrapped in double quotes.
  * @param  { String } selectorType
  * @return { Function }
  * @param  { Object } element
  * @return { String }
  */
+export const getData = ( selectorType, attributes ) => {
+  for ( let i = 0; i < attributes.length; i++ ) {
+    const { nodeName, value } = attributes[ i ]
 
-function needsQuote( v )
-{
-  // if the escaped value is different from
-  // the non escaped value then we know
-  // we need to quote the value
-  return v !== CSS.escape( v );
-}
-
-/**
-  * Method to wrap the HTML attribute selector text in double quotes if there's missing
-  * @param {string} selector -> a string that represents a HTML attribute selector
-  * @returns {string} -> the selector wrapped in double quotes if needed
-  */
-const _setQuotesToAttrSelector = (selector) => {
-  const [attributeName, attributeValue] = selector.split('=')
-
-  if (attributeName && attributeValue) {
-    const hasQuotes = (attributeValue[0] === '"' || attributeValue[0] === '\'')
-
-    if (selector.split('').includes('[', ']') && !hasQuotes) {
-      return `[${attributeName.replace('[', '')}="${attributeValue.replace(']', '"]')}`
-    }
-}
-
-  return selector
-}
-
-export const getData = ( selectorType, attributes ) =>
-{
-  for ( let i = 0; i < attributes.length; i++ )
-  {
-    // extract node name + value
-    const { nodeName, value } = attributes[ i ];
-
-    // if this matches our selector
-    if ( nodeName === selectorType )
-    {
-      if ( value )
-      {
-        if ( needsQuote( value ) )
-        {
-          // if we have value that needs quotes
-          return _setQuotesToAttrSelector(`[${nodeName}="${value}"]`);
-        }
-
-        return _setQuotesToAttrSelector(`[${nodeName}=${value}]`);
-      }
-
-      return _setQuotesToAttrSelector(`[${nodeName}]`);
-    }
+    if ( nodeName === selectorType ) return `[${nodeName}="${value}"]`
   }
 
-  return null;
-};
+  return null
+}

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ import { getData } from './getData';
 const dataRegex = /^data-(.+)/;
 
 /**
- * Returns all the selectors of the elmenet
+ * Returns all the selectors of the element
  * @param  { Object } element
  * @return { Object }
  */

--- a/test/unique-selector.js
+++ b/test/unique-selector.js
@@ -133,14 +133,4 @@ describe( 'Unique Selector Tests', () =>
     const uniqueSelector = unique( findNode, { selectorTypes : ['data-foo-bar'] } );
     expect( uniqueSelector ).to.equal( '[data-foo-bar="button 123"]' );
   } );
-
-  it( 'data-foo without value', () =>
-  {
-    $( 'body' ).get( 0 ).innerHTML = ''; // Clear previous appends
-    $( 'body' ).append( '<div data-foo class="test7"></div>' );
-    const findNode = $( 'body' ).find( '.test7' ).get( 0 );
-    const uniqueSelector = unique( findNode, { selectorTypes : ['data-foo'] } );
-    expect( uniqueSelector ).to.equal( '[data-foo]' );
-  } );
-
 } );

--- a/test/unique-selector.js
+++ b/test/unique-selector.js
@@ -133,4 +133,14 @@ describe( 'Unique Selector Tests', () =>
     const uniqueSelector = unique( findNode, { selectorTypes : ['data-foo-bar'] } );
     expect( uniqueSelector ).to.equal( '[data-foo-bar="button 123"]' );
   } );
+
+  it( 'data-foo without value', () =>
+  {
+    $( 'body' ).get( 0 ).innerHTML = ''; // Clear previous appends
+    $( 'body' ).append( '<div data-foo class="test7"></div>' );
+    const findNode = $( 'body' ).find( '.test7' ).get( 0 );
+    const uniqueSelector = unique( findNode, { selectorTypes : ['data-foo'] } );
+    expect( uniqueSelector ).to.equal( '[data-foo]' );
+  } );
+
 } );

--- a/test/unique-selector.js
+++ b/test/unique-selector.js
@@ -113,7 +113,7 @@ describe( 'Unique Selector Tests', () =>
     $( 'body' ).append( '<div data-foo="so" class="test6"></div>' );
     const findNode = $( 'body' ).find( '.test6' ).get( 0 );
     const uniqueSelector = unique( findNode, { selectorTypes : ['data-foo'] } );
-    expect( uniqueSelector ).to.equal( '[data-foo=so]' );
+    expect( uniqueSelector ).to.equal( '[data-foo="so"]' );
   } );
 
   it( 'data-foo-bar-baz', () =>
@@ -122,7 +122,7 @@ describe( 'Unique Selector Tests', () =>
     $( 'body' ).append( '<div data-foo-bar-baz="so" class="test6"></div>' );
     const findNode = $( 'body' ).find( '.test6' ).get( 0 );
     const uniqueSelector = unique( findNode, { selectorTypes : ['data-foo-bar-baz'] } );
-    expect( uniqueSelector ).to.equal( '[data-foo-bar-baz=so]' );
+    expect( uniqueSelector ).to.equal( '[data-foo-bar-baz="so"]' );
   } );
 
   it( 'data-foo-bar with quotes', () =>


### PR DESCRIPTION
**What was changed with this Pull Request?**

- Added `method` to check for `data attributes selectors` without `double quotes` & wrap `double quotes` around them.
- Updated `unit` tests.
- Fixed small typo 😉 

**Why was this change needed?**

It was to resolve a bug in the `Cypress Playground Selector` [here](https://github.com/cypress-io/cypress/issues/1884).

**Passing unit tests**

<img width="813" alt="Screen Shot 2021-10-22 at 11 46 48 PM" src="https://user-images.githubusercontent.com/32891808/138541797-c67a63b0-1779-4560-b34c-b02382011413.png">
