### PR TITLE
feat: Enable `name` attribute as an independent selector config

### DIFF
--- a/src/getName.js
+++ b/src/getName.js
@@ -1,5 +1,3 @@
-import 'css.escape';
-
 /**
  * Returns the `name` attribute of the element (if one exists)
  * @param  { Object } element

--- a/src/getName.js
+++ b/src/getName.js
@@ -1,0 +1,17 @@
+import 'css.escape';
+
+/**
+ * Returns the `name` attribute of the element (if one exists)
+ * @param  { Object } element
+ * @return { String }
+ */
+export function getName( el )
+{
+  const name = el.getAttribute( 'name' );
+
+  if( name !== null && name !== '')
+  {
+    return `[name="${name}"]`;
+  }
+  return null;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ import { getID } from './getID';
 import { getClassSelectors } from './getClasses';
 import { getCombinations } from './getCombinations';
 import { getAttributes } from './getAttributes';
+import { getName } from './getName'
 import { getNthChild } from './getNthChild';
 import { getTag } from './getTag';
 import { isUnique } from './isUnique';
@@ -28,6 +29,7 @@ function getAllSelectors( el, selectors, attributesToIgnore )
       'attributes' : elem => getAttributes( elem, attributesToIgnore ),
       'class'      : getClassSelectors,
       'id'         : getID,
+      'name'       : getName,
     };
 
   return selectors
@@ -135,6 +137,7 @@ function getUniqueSelector( element, selectorTypes, attributesToIgnore )
     {
       case 'data' :
       case 'id' :
+      case 'name':
       case 'tag':
         if ( testUniqueness( element, selector ) )
         {
@@ -173,7 +176,7 @@ function getUniqueSelector( element, selectorTypes, attributesToIgnore )
 
 export default function unique( el, options={} ) {
   const { 
-    selectorTypes=['id', 'class', 'tag', 'nth-child'], 
+    selectorTypes=['id', 'name', 'class', 'tag', 'nth-child'], 
     attributesToIgnore= ['id', 'class', 'length'],
     selectorCache,
     isUniqueCache

--- a/test/unique-selector.js
+++ b/test/unique-selector.js
@@ -143,4 +143,25 @@ describe( 'Unique Selector Tests', () =>
     expect( uniqueSelector ).to.equal( '[data-foo]' );
   } );
 
+  describe('name', () => {
+    beforeEach(() => {
+      $( 'body' ).get( 0 ).innerHTML = ''; // Clear previous appends
+    })
+
+    it( 'with value', () =>
+    {
+      $( 'body' ).append( '<div name="so" class="test3"></div>' );
+      const findNode = $( 'body' ).find( '.test3' ).get( 0 );
+      const uniqueSelector = unique( findNode );
+      expect( uniqueSelector ).to.equal( '[name="so"]' );
+    } );
+
+    it( 'without value', () =>
+    {
+      $( 'body' ).append( '<div name class="test3"></div>' );
+      const findNode = $( 'body' ).find( '.test3' ).get( 0 );
+      const uniqueSelector = unique( findNode );
+      expect( uniqueSelector ).to.equal( '.test3' );
+    } );
+  })
 } );


### PR DESCRIPTION
Currently, the `name` attribute would only be utilized in a generated selector if a class-based option cannot be created. For UI Coverage several issues exist where we need to generate selectors around form fields and those can be identified in a more stable manner using the `name` attribute in situations where `id` is not present.

https://cypress-io.atlassian.net/browse/CYCLOUD-2174?focusedCommentId=30643
https://cypress-io.atlassian.net/browse/CYCLOUD-2111


I've chosen to break this out as a separate option in parallel with the existing `attributes` option - using that existing option would require elevating `attributes` above `class` and would have a much broader impact on the style & structure of generated selectors beyond the very targeted behavior change I'm looking for.

_Reviewer note:_ I **think** I don't have to do a `CSS.escape` on the attribute value here since it's inside quotes, but correct me if I'm wrong