### PR TITLE
feat: Allow specifying preferred attributes

### DIFF
--- a/src/getAttribute.js
+++ b/src/getAttribute.js
@@ -1,11 +1,11 @@
 /**
- * Returns the data-{dataAttr} selector of the element
- * @param  { String } selectorType - The type of selector to return.
+ * Returns the {attr} selector of the element
+ * @param  { String } selectorType - The attribute selector to return.
  * @param  { String } attributes - The attributes of the element.
- * @return { String | null } - The data-{dataAttr} selector of the element.
+ * @return { String | null } - The {attr} selector of the element.
  */
 
-export const getData = ( selectorType, attributes ) =>
+export const getAttribute = ( selectorType, attributes ) =>
 {
   for ( let i = 0; i < attributes.length; i++ )
   {

--- a/src/index.js
+++ b/src/index.js
@@ -11,9 +11,10 @@ import { getNthChild } from './getNthChild';
 import { getTag } from './getTag';
 import { isUnique } from './isUnique';
 import { getParents } from './getParents';
-import { getData } from './getData';
+import { getAttribute } from './getAttribute';
 
-const dataRegex = /^data-(.+)/;
+const dataRegex = /^data-.+/;
+const attrRegex = /^attribute-(.+)/m;
 
 /**
  * Returns all the selectors of the element
@@ -33,7 +34,7 @@ function getAllSelectors( el, selectors, attributesToIgnore )
     };
 
   return selectors
-  .filter( ( selector ) => !dataRegex.test( selector ) )
+  .filter( ( selector ) => !dataRegex.test( selector ) && !attrRegex.test( selector ) )
   .reduce( ( res, next ) =>
   {
     res[ next ] = funcs[ next ]( el );
@@ -119,15 +120,18 @@ function getUniqueSelector( element, selectorTypes, attributesToIgnore )
     let selector = elementSelectors[ selectorType ];
 
     // if we are a data attribute
-    if ( dataRegex.test( selectorType ) )
+    const isDataAttributeSelectorType = dataRegex.test(selectorType)
+    const isAttributeSelectorType = !isDataAttributeSelectorType && attrRegex.test(selectorType)
+    if ( isDataAttributeSelectorType || isAttributeSelectorType )
     {
-      const dataSelector = getData( selectorType, attributes );
+      const attributeToQuery = isDataAttributeSelectorType ? selectorType : selectorType.replace(attrRegex, '$1')
+      const attributeSelector = getAttribute( attributeToQuery, attributes );
 
-      // if we found a selector via data attributes
-      if ( dataSelector )
+      // if we found a selector via attribute
+      if ( attributeSelector )
       {
-        selector = dataSelector;
-        selectorType = 'data';
+        selector = attributeSelector;
+        selectorType = 'attribute';
       }
     }
 
@@ -135,7 +139,7 @@ function getUniqueSelector( element, selectorTypes, attributesToIgnore )
 
     switch ( selectorType )
     {
-      case 'data' :
+      case 'attribute' :
       case 'id' :
       case 'name':
       case 'tag':

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ import { getParents } from './getParents';
 import { getAttribute } from './getAttribute';
 
 const dataRegex = /^data-.+/;
-const attrRegex = /^attribute-(.+)/m;
+const attrRegex = /^attribute:(.+)/m;
 
 /**
  * Returns all the selectors of the element

--- a/test/unique-selector.js
+++ b/test/unique-selector.js
@@ -150,7 +150,7 @@ describe( 'Unique Selector Tests', () =>
       $( 'body' ).get( 0 ).innerHTML = ''; // Clear previous appends
       $( 'body' ).append( '<div contenteditable class="test8"></div>' );
       const findNode = $( 'body' ).find( '.test8' ).get( 0 );
-      const uniqueSelector = unique( findNode, { selectorTypes : ['attribute-contenteditable'] } );
+      const uniqueSelector = unique( findNode, { selectorTypes : ['attribute:contenteditable'] } );
       expect( uniqueSelector ).to.equal( '[contenteditable]' );
     })
     
@@ -158,7 +158,7 @@ describe( 'Unique Selector Tests', () =>
       $( 'body' ).get( 0 ).innerHTML = ''; // Clear previous appends
       $( 'body' ).append( '<div role="button" class="test9"></div>' );
       const findNode = $( 'body' ).find( '.test9' ).get( 0 );
-      const uniqueSelector = unique( findNode, { selectorTypes : ['attribute-role'] } );
+      const uniqueSelector = unique( findNode, { selectorTypes : ['attribute:role'] } );
       expect( uniqueSelector ).to.equal( '[role="button"]' );
     })
   })

--- a/test/unique-selector.js
+++ b/test/unique-selector.js
@@ -107,41 +107,62 @@ describe( 'Unique Selector Tests', () =>
     expect( uniqueSelector ).to.equal( '[test="5"]' );
   } );
 
-  it( 'data-foo', () =>
-  {
-    $( 'body' ).get( 0 ).innerHTML = ''; // Clear previous appends
-    $( 'body' ).append( '<div data-foo="so" class="test6"></div>' );
-    const findNode = $( 'body' ).find( '.test6' ).get( 0 );
-    const uniqueSelector = unique( findNode, { selectorTypes : ['data-foo'] } );
-    expect( uniqueSelector ).to.equal( '[data-foo="so"]' );
-  } );
+  describe('data attribute', () => {
+    it( 'data-foo', () =>
+    {
+      $( 'body' ).get( 0 ).innerHTML = ''; // Clear previous appends
+      $( 'body' ).append( '<div data-foo="so" class="test6"></div>' );
+      const findNode = $( 'body' ).find( '.test6' ).get( 0 );
+      const uniqueSelector = unique( findNode, { selectorTypes : ['data-foo'] } );
+      expect( uniqueSelector ).to.equal( '[data-foo="so"]' );
+    } );
 
-  it( 'data-foo-bar-baz', () =>
-  {
-    $( 'body' ).get( 0 ).innerHTML = ''; // Clear previous appends
-    $( 'body' ).append( '<div data-foo-bar-baz="so" class="test6"></div>' );
-    const findNode = $( 'body' ).find( '.test6' ).get( 0 );
-    const uniqueSelector = unique( findNode, { selectorTypes : ['data-foo-bar-baz'] } );
-    expect( uniqueSelector ).to.equal( '[data-foo-bar-baz="so"]' );
-  } );
+    it( 'data-foo-bar-baz', () =>
+    {
+      $( 'body' ).get( 0 ).innerHTML = ''; // Clear previous appends
+      $( 'body' ).append( '<div data-foo-bar-baz="so" class="test6"></div>' );
+      const findNode = $( 'body' ).find( '.test6' ).get( 0 );
+      const uniqueSelector = unique( findNode, { selectorTypes : ['data-foo-bar-baz'] } );
+      expect( uniqueSelector ).to.equal( '[data-foo-bar-baz="so"]' );
+    } );
 
-  it( 'data-foo-bar with quotes', () =>
-  {
-    $( 'body' ).get( 0 ).innerHTML = ''; // Clear previous appends
-    $( 'body' ).append( '<div data-foo-bar="button 123" class="test7"></div>' );
-    const findNode = $( 'body' ).find( '.test7' ).get( 0 );
-    const uniqueSelector = unique( findNode, { selectorTypes : ['data-foo-bar'] } );
-    expect( uniqueSelector ).to.equal( '[data-foo-bar="button 123"]' );
-  } );
+    it( 'data-foo-bar with quotes', () =>
+    {
+      $( 'body' ).get( 0 ).innerHTML = ''; // Clear previous appends
+      $( 'body' ).append( '<div data-foo-bar="button 123" class="test7"></div>' );
+      const findNode = $( 'body' ).find( '.test7' ).get( 0 );
+      const uniqueSelector = unique( findNode, { selectorTypes : ['data-foo-bar'] } );
+      expect( uniqueSelector ).to.equal( '[data-foo-bar="button 123"]' );
+    } );
 
-  it( 'data-foo without value', () =>
-  {
-    $( 'body' ).get( 0 ).innerHTML = ''; // Clear previous appends
-    $( 'body' ).append( '<div data-foo class="test7"></div>' );
-    const findNode = $( 'body' ).find( '.test7' ).get( 0 );
-    const uniqueSelector = unique( findNode, { selectorTypes : ['data-foo'] } );
-    expect( uniqueSelector ).to.equal( '[data-foo]' );
-  } );
+    it( 'data-foo without value', () =>
+    {
+      $( 'body' ).get( 0 ).innerHTML = ''; // Clear previous appends
+      $( 'body' ).append( '<div data-foo class="test7"></div>' );
+      const findNode = $( 'body' ).find( '.test7' ).get( 0 );
+      const uniqueSelector = unique( findNode, { selectorTypes : ['data-foo'] } );
+      expect( uniqueSelector ).to.equal( '[data-foo]' );
+    } );
+  });
+
+  describe('standard attribute', () => {
+    it('attribute without value', () => {
+      $( 'body' ).get( 0 ).innerHTML = ''; // Clear previous appends
+      $( 'body' ).append( '<div contenteditable class="test8"></div>' );
+      const findNode = $( 'body' ).find( '.test8' ).get( 0 );
+      const uniqueSelector = unique( findNode, { selectorTypes : ['attribute-contenteditable'] } );
+      expect( uniqueSelector ).to.equal( '[contenteditable]' );
+    })
+    
+    it('attribute with value', () => {
+      $( 'body' ).get( 0 ).innerHTML = ''; // Clear previous appends
+      $( 'body' ).append( '<div role="button" class="test9"></div>' );
+      const findNode = $( 'body' ).find( '.test9' ).get( 0 );
+      const uniqueSelector = unique( findNode, { selectorTypes : ['attribute-role'] } );
+      expect( uniqueSelector ).to.equal( '[role="button"]' );
+    })
+  })
+  
 
   describe('name', () => {
     beforeEach(() => {


### PR DESCRIPTION
This enables providing a set of preferred attributes to use when building selectors - this is different from the existing `attributes` selector type which builds a selector using any permutation of attributes. The impetus of this change is in UI Coverage there are cases where we want to leverage specific vendor/custom attributes which are significant but are not `data-*` attributes - these are technically invalid per the HTML spec but are widely used regardless. Specifically, the AG Grid library uses a `row-id` attribute that we want to leverage whenever possible since it helps form a stable identifier when there are auto-generated `id` values.

This follows a similar pattern to the existing `data-*` attribute handling. You can supply a `attribute-*` selectorType which will be evaluated exactly the same after stripping `attribute-` off the front. e.g. `attribute-role` would use the `role` attribute, `attribute-more-cowbell` would use `more-cowbell`.

Technically this pattern could replace the dedicated `data-*` path by providing a value of `attribute-data-cy`, but in the interests of making this a non-breaking change I've left that path intact