### PR TITLE
feat: Allow selector traits to be conditionally filtered

### DIFF
--- a/src/getAttribute.js
+++ b/src/getAttribute.js
@@ -1,29 +1,21 @@
 /**
  * Returns the {attr} selector of the element
- * @param  { String } selectorType - The attribute selector to return.
- * @param  { String } attributes - The attributes of the element.
+ * @param  { Element } el - The element.
+ * @param  { String } attribute - The attribute name.
  * @return { String | null } - The {attr} selector of the element.
  */
-
-export const getAttribute = ( selectorType, attributes ) =>
+export const getAttributeSelector = ( el, attribute ) =>
 {
-  for ( let i = 0; i < attributes.length; i++ )
-  {
-    // extract node name + value
-    const { nodeName, value } = attributes[ i ];
+  const attributeValue = el.getAttribute(attribute)
 
-    // if this matches our selector
-    if ( nodeName === selectorType )
-    {
-      if ( value )
-      {
-        // if we have value that needs quotes
-        return `[${nodeName}="${value}"]`;
-      }
-
-      return `[${nodeName}]`;
-    }
+  if (attributeValue === null) {
+    return null
   }
 
-  return null;
+  if (attributeValue) {
+    // if we have value that needs quotes
+    return `[${attribute}="${attributeValue}"]`;
+  }
+
+  return `[${attribute}]`;
 };

--- a/src/getAttributes.js
+++ b/src/getAttributes.js
@@ -1,17 +1,18 @@
 /**
  * Returns the Attribute selectors of the element
- * @param  { DOM Element } element
+ * @param  { Element } element
  * @param  { Array } array of attributes to ignore
+ * @param { Function } filter
  * @return { Array }
  */
-export function getAttributes( el, attributesToIgnore = ['id', 'class', 'length'] )
+export function getAttributes( el, attributesToIgnore = ['id', 'class', 'length'], filter )
 {
   const { attributes } = el;
   const attrs = [ ...attributes ];
 
   return attrs.reduce( ( sum, next ) =>
   {
-    if ( ! ( attributesToIgnore.indexOf( next.nodeName ) > -1 ) )
+    if ( ! ( attributesToIgnore.indexOf( next.nodeName ) > -1 ) && (!filter || filter('attributes', next.nodeName, next.value)) )
     {
       sum.push( `[${next.nodeName}="${next.value}"]` );
     }

--- a/src/getClasses.js
+++ b/src/getClasses.js
@@ -3,10 +3,11 @@ import 'css.escape';
 /**
  * Get class names for an element
  *
- * @pararm { Element } el
+ * @param { Element } el
+ * @param { Function } filter
  * @return { Array }
  */
-export function getClasses( el )
+export function getClasses( el, filter )
 {
   if( !el.hasAttribute( 'class' ) )
   {
@@ -14,25 +15,28 @@ export function getClasses( el )
   }
 
   try {
-    return Array.prototype.slice.call( el.classList );
+    return Array.prototype.slice.call( el.classList )
+    .filter((cls) => !filter || filter('class', 'class', cls));
   } catch (e) {
     let className = el.getAttribute( 'class' );
 
     // remove duplicate and leading/trailing whitespaces
-    className = className.trim().replace( /\s+/g, ' ' );
+    className = className.trim()
 
-    // split into separate classnames
-    return className.split( ' ' );
+    // split into separate classnames, perform filtering
+    return className.split(/\s+/g)
+      .filter((cls) => !filter || filter('class', 'class', cls));
   }
 }
 
 /**
  * Returns the Class selectors of the element
  * @param  { Object } element
+ * @param { Function } filter
  * @return { Array }
  */
-export function getClassSelectors( el )
+export function getClassSelectors( el, filter )
 {
-  const classList = getClasses( el ).filter( Boolean );
+  const classList = getClasses( el, filter ).filter( Boolean );
   return classList.map( cl => `.${CSS.escape( cl )}` );
 }

--- a/src/getID.js
+++ b/src/getID.js
@@ -3,13 +3,14 @@ import 'css.escape';
 /**
  * Returns the Tag of the element
  * @param  { Object } element
+ * @param { Function } filter
  * @return { String }
  */
-export function getID( el )
+export function getID( el, filter )
 {
   const id = el.getAttribute( 'id' );
 
-  if( id !== null && id !== '')
+  if( id !== null && id !== '' && (!filter || filter('id', 'id', id)))
   {
     return `#${CSS.escape( id )}`;
   }

--- a/src/getName.js
+++ b/src/getName.js
@@ -1,13 +1,14 @@
 /**
  * Returns the `name` attribute of the element (if one exists)
  * @param  { Object } element
+ * @param { Function } filter
  * @return { String }
  */
-export function getName( el )
+export function getName( el, filter )
 {
   const name = el.getAttribute( 'name' );
 
-  if( name !== null && name !== '')
+  if( name !== null && name !== '' && (!filter || filter('name', 'name', name)))
   {
     return `[name="${name}"]`;
   }

--- a/src/getNthChild.js
+++ b/src/getNthChild.js
@@ -3,9 +3,10 @@ import { isElement } from './isElement';
 /**
  * Returns the selectors based on the position of the element relative to its siblings
  * @param  { Object } element
+ * @param { Function } filter
  * @return { Array }
  */
-export function getNthChild( element )
+export function getNthChild( element, filter )
 {
   let counter = 0;
   let k;
@@ -22,7 +23,7 @@ export function getNthChild( element )
       if( isElement( sibling ) )
       {
         counter++;
-        if( sibling === element )
+        if( sibling === element && (!filter || filter('nth-child', 'nth-child', counter)) )
         {
           return `:nth-child(${counter})`;
         }

--- a/src/getTag.js
+++ b/src/getTag.js
@@ -1,9 +1,16 @@
 /**
  * Returns the Tag of the element
  * @param  { Object } element
+ * @param { Function } filter
  * @return { String }
  */
-export function getTag( el )
+export function getTag( el, filter )
 {
-  return el.tagName.toLowerCase().replace(/:/g, '\\:');
+  const tagName = el.tagName.toLowerCase().replace(/:/g, '\\:')
+
+  if (filter && !filter('tag', 'tag', tagName)) {
+    return null;
+  }
+
+  return tagName;
 }

--- a/test/unique-selector.js
+++ b/test/unique-selector.js
@@ -6,10 +6,12 @@ const $ = require( 'jquery' )( (new JSDOM()).window );
 
 describe( 'Unique Selector Tests', () =>
 {
+  beforeEach(() => {
+    $( 'body' ).get( 0 ).innerHTML = ''; // Clear previous appends
+  })
 
   it( 'ID', () =>
   {
-    $( 'body' ).get( 0 ).innerHTML = ''; // Clear previous appends
     $( 'body' ).append( '<div id="so" class="test3"></div>' );
     const findNode = $( 'body' ).find( '.test3' ).get( 0 );
     const uniqueSelector = unique( findNode );
@@ -18,16 +20,31 @@ describe( 'Unique Selector Tests', () =>
 
   it( 'ID that needs escaping', () =>
   {
-    $( 'body' ).get( 0 ).innerHTML = ''; // Clear previous appends
     $( 'body' ).append( '<div id="123" class="test3"></div>' );
     const findNode = $( 'body' ).find( '.test3' ).get( 0 );
     const uniqueSelector = unique( findNode );
     expect( uniqueSelector ).to.equal( '#\\31 23' );
   } );
 
+  it('ID filters appropriately', () => {
+    const filters = {
+      'id': (type, key, value) => {
+        return /oo/.test(value)
+      }
+    }
+    let el = $.parseHTML( '<div id="foo"></div>' )[0];
+    $(el).appendTo('body')
+    let uniqueSelector = unique( el, { filters } );
+    expect( uniqueSelector ).to.equal( '#foo' );
+
+    el = $.parseHTML( '<div id="bar"></div>' )[0];
+    $(el).appendTo('body')
+    uniqueSelector = unique( el, { filters } );
+    expect( uniqueSelector ).to.equal( 'body > :nth-child(2)' );
+  });
+
   it( 'Class', () =>
   {
-    $( 'body' ).get( 0 ).innerHTML = ''; // Clear previous appends
     $( 'body' ).append( '<div class="test2"></div>' );
     const findNode = $( 'body' ).find( '.test2' ).get( 0 );
     const uniqueSelector = unique( findNode );
@@ -36,7 +53,6 @@ describe( 'Unique Selector Tests', () =>
 
   it( 'Class that needs escaping', () =>
   {
-    $( 'body' ).get( 0 ).innerHTML = ''; // Clear previous appends
     $( 'body' ).append( '<div class="@test test2"></div>' );
     const findNode = $( 'body' ).find( '.test2' ).get( 0 );
     const uniqueSelector = unique( findNode );
@@ -45,7 +61,6 @@ describe( 'Unique Selector Tests', () =>
 
   it( 'Classes', () =>
   {
-    $( 'body' ).get( 0 ).innerHTML = ''; // Clear previous appends
     $( 'body' ).append( '<div class="test2"></div><div class="test2"></div>' );
     const findNode = $( 'body' ).find( '.test2' ).get( 0 );
     const uniqueSelector = unique( findNode );
@@ -54,7 +69,6 @@ describe( 'Unique Selector Tests', () =>
 
   it( 'Classes', () =>
   {
-    $( 'body' ).get( 0 ).innerHTML = ''; // Clear previous appends
     $( 'body' ).append( '<div class="test2 ca cb cc cd cx"></div><div class="test2 ca cb cc cd ce"></div><div class="test2 ca cb cc cd ce"></div><div class="test2 ca cb cd ce cf cx"></div>' );
     const findNode = $( 'body' ).find( '.test2' ).get( 0 );
     const uniqueSelector = unique( findNode );
@@ -63,16 +77,31 @@ describe( 'Unique Selector Tests', () =>
 
   it( 'Classes with newline', () =>
   {
-    $( 'body' ).get( 0 ).innerHTML = ''; // Clear previous appends
     $( 'body' ).append( '<div class="test2\n ca\n cb\n cc\n cd\n cx"></div><div class="test2\n ca\n cb\n cc\n cd\n ce"></div><div class="test2\n ca\n cb\n cc\n cd\n ce"></div><div class="test2\n ca\n cb\n cd\n ce\n cf\n cx"></div>' );
     const findNode = $( 'body' ).find( '.test2' ).get( 0 );
     const uniqueSelector = unique( findNode );
     expect( uniqueSelector ).to.equal( '.cc.cx' );
   } );
 
+  it('Classes filters appropriately', () => {
+    const filters = {
+      'class': (type, key, value) => {
+        return value.startsWith('a')
+      }
+    }
+    let el = $.parseHTML( '<div class="a1"></div>' )[0];
+    $(el).appendTo('body')
+    let uniqueSelector = unique( el, { filters } );
+    expect( uniqueSelector ).to.equal( '.a1' );
+
+    el = $.parseHTML( '<div class="b1 a2"></div>' )[0];
+    $(el).appendTo('body')
+    uniqueSelector = unique( el, { filters } );
+    expect( uniqueSelector ).to.equal( '.a2' );
+  });
+
   it( 'Tag', () =>
   {
-    $( 'body' ).get( 0 ).innerHTML = ''; // Clear previous appends
     $( 'body' ).append( '<div class="test2"><span></span></div><div class="test2"></div>' );
     const findNode = $( '.test2' ).find( 'span' ).get( 0 );
     const uniqueSelector = unique( findNode );
@@ -82,7 +111,6 @@ describe( 'Unique Selector Tests', () =>
 
   it( 'Tag', () =>
   {
-    $( 'body' ).get( 0 ).innerHTML = ''; // Clear previous appends
     $( 'body' ).append( '<div class="test5"><span></span></div><div class="test5"><span></span></div>' );
     const findNode = $( '.test5' ).find( 'span' ).get( 0 );
     const uniqueSelector = unique( findNode );
@@ -91,7 +119,6 @@ describe( 'Unique Selector Tests', () =>
 
   it( 'Tag', () =>
   {
-    $( 'body' ).get( 0 ).innerHTML = ''; // Clear previous appends
     $( 'body' ).append( '<div class="test5"><span><ul><li><a></a></li></ul></span></div><div class="test5"><span></span></div>' );
     const findNode = $( '.test5' ).find( 'a' ).get( 0 );
     const uniqueSelector = unique( findNode );
@@ -100,17 +127,31 @@ describe( 'Unique Selector Tests', () =>
 
   it( 'Attributes', () =>
   {
-    $( 'body' ).get( 0 ).innerHTML = ''; // Clear previous appends
     $( 'body' ).append( '<div class="test5" test="5"></div>' );
     const findNode = $( '.test5' ).get( 0 );
     const uniqueSelector = unique( findNode, { selectorTypes : ['attributes'] } );
     expect( uniqueSelector ).to.equal( '[test="5"]' );
   } );
 
+  it('Attributes does not consider specified attribute matchers', () => {
+    $( 'body' ).append( '<div a="1" data-foo="1"></div>' );
+    const el = $( 'div' ).get( 0 );
+    // Add selectorTypes for `data-foo` and `attribute:a` but use filters to reject their use
+    // `attributes` selector type should *not* use those attributes since they were considered
+    // by other selectorType generators
+    const uniqueSelector = unique( el, {
+      selectorTypes : ['data-foo', 'attribute:a', 'attributes', 'nth-child'],
+      filters: {
+        'data-foo': () => false,
+        'attribute:a': () => false,
+      }
+    } );
+    expect( uniqueSelector ).to.equal( ':nth-child(2) > :nth-child(1)' );
+  });
+
   describe('data attribute', () => {
     it( 'data-foo', () =>
     {
-      $( 'body' ).get( 0 ).innerHTML = ''; // Clear previous appends
       $( 'body' ).append( '<div data-foo="so" class="test6"></div>' );
       const findNode = $( 'body' ).find( '.test6' ).get( 0 );
       const uniqueSelector = unique( findNode, { selectorTypes : ['data-foo'] } );
@@ -119,7 +160,6 @@ describe( 'Unique Selector Tests', () =>
 
     it( 'data-foo-bar-baz', () =>
     {
-      $( 'body' ).get( 0 ).innerHTML = ''; // Clear previous appends
       $( 'body' ).append( '<div data-foo-bar-baz="so" class="test6"></div>' );
       const findNode = $( 'body' ).find( '.test6' ).get( 0 );
       const uniqueSelector = unique( findNode, { selectorTypes : ['data-foo-bar-baz'] } );
@@ -128,7 +168,6 @@ describe( 'Unique Selector Tests', () =>
 
     it( 'data-foo-bar with quotes', () =>
     {
-      $( 'body' ).get( 0 ).innerHTML = ''; // Clear previous appends
       $( 'body' ).append( '<div data-foo-bar="button 123" class="test7"></div>' );
       const findNode = $( 'body' ).find( '.test7' ).get( 0 );
       const uniqueSelector = unique( findNode, { selectorTypes : ['data-foo-bar'] } );
@@ -137,17 +176,32 @@ describe( 'Unique Selector Tests', () =>
 
     it( 'data-foo without value', () =>
     {
-      $( 'body' ).get( 0 ).innerHTML = ''; // Clear previous appends
       $( 'body' ).append( '<div data-foo class="test7"></div>' );
       const findNode = $( 'body' ).find( '.test7' ).get( 0 );
       const uniqueSelector = unique( findNode, { selectorTypes : ['data-foo'] } );
       expect( uniqueSelector ).to.equal( '[data-foo]' );
     } );
+
+    it('filters appropriately', () => {
+      const filters = {
+        'data-foo': (type, key, value) => {
+          return value === 'abc'
+        }
+      }
+      let el = $.parseHTML( '<div data-foo="abc" class="test1"></div>' )[0];
+      $(el).appendTo('body')
+      let uniqueSelector = unique( el, { filters, selectorTypes : ['data-foo', 'class'] } );
+      expect( uniqueSelector ).to.equal( '[data-foo="abc"]' );
+
+      el = $.parseHTML( '<div data-foo="def" class="test2"></div>' )[0];
+      $(el).appendTo('body')
+      uniqueSelector = unique( el, { filters, selectorTypes : ['data-foo', 'class'] } );
+      expect( uniqueSelector ).to.equal( '.test2' );
+    })
   });
 
   describe('standard attribute', () => {
     it('attribute without value', () => {
-      $( 'body' ).get( 0 ).innerHTML = ''; // Clear previous appends
       $( 'body' ).append( '<div contenteditable class="test8"></div>' );
       const findNode = $( 'body' ).find( '.test8' ).get( 0 );
       const uniqueSelector = unique( findNode, { selectorTypes : ['attribute:contenteditable'] } );
@@ -155,20 +209,31 @@ describe( 'Unique Selector Tests', () =>
     })
     
     it('attribute with value', () => {
-      $( 'body' ).get( 0 ).innerHTML = ''; // Clear previous appends
       $( 'body' ).append( '<div role="button" class="test9"></div>' );
       const findNode = $( 'body' ).find( '.test9' ).get( 0 );
       const uniqueSelector = unique( findNode, { selectorTypes : ['attribute:role'] } );
       expect( uniqueSelector ).to.equal( '[role="button"]' );
     })
+
+    it('filters appropriately', () => {
+      const filters = {
+        'attribute:role': (type, key, value) => {
+          return value === 'abc'
+        }
+      }
+      let el = $.parseHTML( '<div role="abc" class="test1"></div>' )[0];
+      $(el).appendTo('body')
+      let uniqueSelector = unique( el, { filters, selectorTypes : ['attribute:role', 'class'] } );
+      expect( uniqueSelector ).to.equal( '[role="abc"]' );
+
+      el = $.parseHTML( '<div role="def" class="test2"></div>' )[0];
+      $(el).appendTo('body')
+      uniqueSelector = unique( el, { filters, selectorTypes : ['attribute:role', 'class'] } );
+      expect( uniqueSelector ).to.equal( '.test2' );
+    })
   })
   
-
   describe('name', () => {
-    beforeEach(() => {
-      $( 'body' ).get( 0 ).innerHTML = ''; // Clear previous appends
-    })
-
     it( 'with value', () =>
     {
       $( 'body' ).append( '<div name="so" class="test3"></div>' );
@@ -184,5 +249,22 @@ describe( 'Unique Selector Tests', () =>
       const uniqueSelector = unique( findNode );
       expect( uniqueSelector ).to.equal( '.test3' );
     } );
+
+    it('filters appropriately', () => {
+      const filters = {
+        'name': (type, key, value) => {
+          return value === 'abc'
+        }
+      }
+      let el = $.parseHTML( '<div name="abc" class="test1"></div>' )[0];
+      $(el).appendTo('body')
+      let uniqueSelector = unique( el, { filters } );
+      expect( uniqueSelector ).to.equal( '[name="abc"]' );
+
+      el = $.parseHTML( '<div name="def" class="test2"></div>' )[0];
+      $(el).appendTo('body')
+      uniqueSelector = unique( el, { filters } );
+      expect( uniqueSelector ).to.equal( '.test2' );
+    })
   })
 } );


### PR DESCRIPTION
Enabling selector traits to be conditionally filtered so that they can be included/excluded based on user-supplied config. The idea is that creating selectors based off `id` could be configured to ignore certain patterns of auto-generated values:

```
unique(
  el,
  {
    selectorTypes: ['id'],
    filters: {
      'id': (type, key, value) => {
        return !isAutoGeneratedValue(value)
      }
    }
  }
)
```

This filtering piggybacks on existing behavior in the selector generation logic to effectively pretend various traits (or portions of traits) just don't exist, thus can't be used when building selectors and automatically falling back to the next-highest-precedence trait.

The initial intent here is to support UICoverage user-supplied config to address auto-generated values breaking element de-duping. This will be primarily around attribute-based selector filters, but for completeness I've added support for filtering all selector types. Aggregate-style traits (`class` and `attributes`) allow filtering by part so that individual attribute names/values and classes can be filtered.

In addition, I've done some minor cleanup of attribute logic (using updated element APIs rather than iterating using older-style APIs).