### PR TITLE
feat: Accept single filter function rather than dict

### DIFF
--- a/src/getAttribute.js
+++ b/src/getAttribute.js
@@ -2,13 +2,14 @@
  * Returns the {attr} selector of the element
  * @param  { Element } el - The element.
  * @param  { String } attribute - The attribute name.
+ * @param { Function } filter
  * @return { String | null } - The {attr} selector of the element.
  */
-export const getAttributeSelector = ( el, attribute ) =>
+export const getAttributeSelector = ( el, attribute, filter ) =>
 {
   const attributeValue = el.getAttribute(attribute)
 
-  if (attributeValue === null) {
+  if (attributeValue === null || (filter && !filter('attribute', attribute, attributeValue))) {
     return null
   }
 

--- a/src/getAttributes.js
+++ b/src/getAttributes.js
@@ -12,7 +12,7 @@ export function getAttributes( el, attributesToIgnore = ['id', 'class', 'length'
 
   return attrs.reduce( ( sum, next ) =>
   {
-    if ( ! ( attributesToIgnore.indexOf( next.nodeName ) > -1 ) && (!filter || filter('attributes', next.nodeName, next.value)) )
+    if ( ! ( attributesToIgnore.indexOf( next.nodeName ) > -1 ) && (!filter || filter('attribute', next.nodeName, next.value)) )
     {
       sum.push( `[${next.nodeName}="${next.value}"]` );
     }

--- a/src/getClasses.js
+++ b/src/getClasses.js
@@ -16,7 +16,7 @@ export function getClasses( el, filter )
 
   try {
     return Array.prototype.slice.call( el.classList )
-    .filter((cls) => !filter || filter('class', 'class', cls));
+    .filter((cls) => !filter || filter('attribute', 'class', cls));
   } catch (e) {
     let className = el.getAttribute( 'class' );
 

--- a/src/getID.js
+++ b/src/getID.js
@@ -10,7 +10,7 @@ export function getID( el, filter )
 {
   const id = el.getAttribute( 'id' );
 
-  if( id !== null && id !== '' && (!filter || filter('id', 'id', id)))
+  if( id !== null && id !== '' && (!filter || filter('attribute', 'id', id)))
   {
     return `#${CSS.escape( id )}`;
   }

--- a/src/getName.js
+++ b/src/getName.js
@@ -8,7 +8,7 @@ export function getName( el, filter )
 {
   const name = el.getAttribute( 'name' );
 
-  if( name !== null && name !== '' && (!filter || filter('name', 'name', name)))
+  if( name !== null && name !== '' && (!filter || filter('attribute', 'name', name)))
   {
     return `[name="${name}"]`;
   }

--- a/src/index.js
+++ b/src/index.js
@@ -17,11 +17,20 @@ const dataRegex = /^data-.+/;
 const attrRegex = /^attribute:(.+)/m;
 
 /**
+ * @typedef Filter
+ * @type {Function}
+ * @param {string} type - the trait being considered ('attribute', 'tag', 'nth-child').
+ * @param {string} key - your trait key (for 'attribute' will be the attribute name, for others will typically be the same as 'type').
+ * @param {string} value - the trait value.
+ * @returns {boolean} whether this trait can be used when building the selector (true = allow). Defaults to 'true' if no value returned.
+ */
+
+/**
  * Returns all the selectors of the element
  * @param  { Object } element
  * @return { Object }
  */
-function getAllSelectors( el, selectors, attributesToIgnore, filters )
+function getAllSelectors( el, selectors, attributesToIgnore, filter )
 {
   const consolidatedAttributesToIgnore = [...attributesToIgnore]
   const nonAttributeSelectors = []
@@ -37,12 +46,12 @@ function getAllSelectors( el, selectors, attributesToIgnore, filters )
 
   const funcs =
     {
-      'tag'        : elem => getTag( elem, filters.tag ),
-      'nth-child'  : elem => getNthChild( elem, filters.nthChild ),
-      'attributes' : elem => getAttributes( elem, consolidatedAttributesToIgnore, filters.attributes ),
-      'class'      : elem => getClassSelectors( elem, filters.class ),
-      'id'         : elem => getID( elem, filters.id ),
-      'name'       : elem => getName (elem, filters.name ),
+      'tag'        : elem => getTag( elem, filter ),
+      'nth-child'  : elem => getNthChild( elem, filter ),
+      'attributes' : elem => getAttributes( elem, consolidatedAttributesToIgnore, filter ),
+      'class'      : elem => getClassSelectors( elem, filter ),
+      'id'         : elem => getID( elem, filter ),
+      'name'       : elem => getName (elem, filter ),
     };
 
   return nonAttributeSelectors
@@ -118,11 +127,11 @@ function getUniqueCombination( element, items, tag )
  * @param  { Array } options
  * @return { String }
  */
-function getUniqueSelector( element, selectorTypes, attributesToIgnore, filters )
+function getUniqueSelector( element, selectorTypes, attributesToIgnore, filter )
 {
   let foundSelector;
 
-  const elementSelectors = getAllSelectors( element, selectorTypes, attributesToIgnore, filters );
+  const elementSelectors = getAllSelectors( element, selectorTypes, attributesToIgnore, filter );
 
   for( let selectorType of selectorTypes )
   {
@@ -134,13 +143,11 @@ function getUniqueSelector( element, selectorTypes, attributesToIgnore, filters 
     if ( isDataAttributeSelectorType || isAttributeSelectorType )
     {
       const attributeToQuery = isDataAttributeSelectorType ? selectorType : selectorType.replace(attrRegex, '$1')
-      const attributeValue = element.getAttribute(attributeToQuery)
-      const attributeFilter = filters[selectorType];
-
+      const attributeSelector = getAttributeSelector(element, attributeToQuery, filter)
       // if we found a selector via attribute
-      if ( attributeValue !== null && (!attributeFilter || attributeFilter(selectorType, attributeToQuery, attributeValue)) )
+      if ( attributeSelector )
       {
-        selector = getAttributeSelector( element, attributeToQuery );
+        selector = getAttributeSelector( element, attributeToQuery, filter );
         selectorType = 'attribute';
       }
     }
@@ -187,10 +194,7 @@ function getUniqueSelector( element, selectorTypes, attributesToIgnore, filters 
  * @param {Object} options (optional) Customize various behaviors of selector generation
  * @param {String[]} options.selectorTypes Specify the set of traits to leverage when building selectors in precedence order
  * @param {String[]} options.attributesToIgnore Specify a set of attributes to *not* leverage when building selectors
- * @param {Object} options.filters Specify a set of filter functions to conditionally reject various traits when building selectors. Keys correspond to a `selectorTypes` entry, values should be a function accepting three parameters:
- * * selectorType: The selector type/category being generated
- * * key: The key being evaluated - this will typically match the `selectorType` except in aggregate types like `attributes`
- * * value: The value to consider. Returning `true` will allow its use in selector generation, `false` will prevent.
+ * @param {Filter} options.filter Provide a filter function to conditionally reject various traits when building selectors.
  * @param {Map<Element, String>} options.selectorCache Provide a cache to improve performance of repeated selector generation - it is the responsibility of the caller to handle cache invalidation. Caching is performed using the input Element as key. This cache handles Element -> Selector caching.
  * @param {Map<String, Boolean>} options.isUniqueCache Provide a cache to improve performance of repeated selector generation - it is the responsibility of the caller to handle cache invalidation. Caching is performed using the input Element as key. This cache handles Selector -> isUnique caching.
  * @return {String}
@@ -201,10 +205,18 @@ export default function unique( el, options={} ) {
   const { 
     selectorTypes=['id', 'name', 'class', 'tag', 'nth-child'], 
     attributesToIgnore= ['id', 'class', 'length'],
-    filters = {},
+    filter,
     selectorCache,
     isUniqueCache
   } = options;
+  // If filter was provided wrap it to ensure a default value of `true` is returned if the provided function fails to return a value
+  const normalizedFilter = filter && function(type, key, value) {
+    const result = filter(type, key, value)
+    if (result === null || result === undefined) {
+      return true
+    }
+    return result
+  }
   const allSelectors = [];
 
   let currentElement = el
@@ -216,7 +228,7 @@ export default function unique( el, options={} ) {
         currentElement,
         selectorTypes,
         attributesToIgnore,
-        filters
+        normalizedFilter
       )
       if (selectorCache) {
         selectorCache.set(currentElement, selector)

--- a/src/index.js
+++ b/src/index.js
@@ -147,7 +147,7 @@ function getUniqueSelector( element, selectorTypes, attributesToIgnore, filter )
       // if we found a selector via attribute
       if ( attributeSelector )
       {
-        selector = getAttributeSelector( element, attributeToQuery, filter );
+        selector = attributeSelector
         selectorType = 'attribute';
       }
     }


### PR DESCRIPTION
[CP-2790](https://cypress-io.atlassian.net/browse/CP-2790)

Updates made in #8 added the ability to provide filter functions to conditionally exclude certain trait values from being used during selector generation. In a nod to performance these were structured to only call a filter function if the trait being considered *exactly matched* the one under consideration (exact attribute name match, usually). However, it is desired that filters be able to supply a regex to match traits (e.g. allow filtering multiple attributes with the same criteria) which necessitates a change in contract to supply a single filter function that encapsulates all the necessary filtering logic. This will have a small performance impact on selector generation since every single trait will need to call into this filter function, but impact can be mitigated by aggressive use of the supplied `type` and `key` params as well as appropriate caching/memoization when crafting the filter param.

_Note:_ I had originally planned to handle caching internally here (since we already are doing so for overall selector gen and isUnique checks) but doing so required pulling in *a lot* of knowledge of how filters are being structured for our specific use case. I backed that out to reduce coupling and believe caching can be handled as efficiently/elegantly by the caller, but if anyone sees a superior approach I'd be interested to hear it since this lib has significant performance implications for UICov.

Once this merges there will be follow-on changes in `cypress-services` side to update this dep and build an appropriate filter function off of config

**Before**
```js
unique(
  element,
  {
    filters: {
      'ng-type': (type, key, value) => value !== 'test',
      'ng-kind': (type, key, value) => value !== 'test'
    }
  }
)
```

**After**
```js
unique(
  element,
  {
    filter: _.memoize(
      (type, key, value) => {
        if (type === 'attribute' && /^((ng-type)|(ng-kind))$/.test(key)) {
          return value !== 'test'
        }
        return true
      },
      (type, key, value) => `${type}${key}${value}`
    )
  }
)
```

[CP-2790]: https://cypress-io.atlassian.net/browse/CP-2790?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ