### PR TITLE
fix: Standardize filter params for `class`

### DIFF
--- a/src/getClasses.js
+++ b/src/getClasses.js
@@ -16,7 +16,7 @@ export function getClasses( el, filter )
 
   try {
     return Array.prototype.slice.call( el.classList )
-    .filter((cls) => !filter || filter('attribute', 'class', cls));
+    .filter((cls) => !filter || filter('class', 'class', cls));
   } catch (e) {
     let className = el.getAttribute( 'class' );
 

--- a/src/index.js
+++ b/src/index.js
@@ -19,7 +19,7 @@ const attrRegex = /^attribute:(.+)/m;
 /**
  * @typedef Filter
  * @type {Function}
- * @param {string} type - the trait being considered ('attribute', 'tag', 'nth-child').
+ * @param {string} type - the trait being considered ('attribute', 'tag', 'nth-child'). As a special case, the `class` attribute is split on whitespace and each token passed individually with a `class` type.
  * @param {string} key - your trait key (for 'attribute' will be the attribute name, for others will typically be the same as 'type').
  * @param {string} value - the trait value.
  * @returns {boolean} whether this trait can be used when building the selector (true = allow). Defaults to 'true' if no value returned.

--- a/test/unique-selector.js
+++ b/test/unique-selector.js
@@ -86,9 +86,11 @@ describe( 'Unique Selector Tests', () =>
 
   it('Classes filters appropriately', () => {
     const filter = (type, key, value) => {
-      if (type === 'attribute' && key === 'class') {
+      if (key === 'class') {
+        expect(type).to.eq('class')
         return value.startsWith('a')
       }
+      expect(type).not.to.eq('class')
       return true
     }
     let el = $.parseHTML( '<div class="a1"></div>' )[0];


### PR DESCRIPTION
Supporting CP-3167

Standardize the parameters passed into the `filter` function when considering the `class` attribute so it's more clear that we're filtering a *portion* of the attribute value (a single class token), not the whole thing.

This library was already splitting the class attribute and filtering individually so a subset of classes could be included/excluded, but was passing an unexpected `type` param which caused the filter function in uicov to not always fire as expected.