### PR TITLE
fix: extra protection around tagName accessor

### DIFF
--- a/src/getTag.js
+++ b/src/getTag.js
@@ -6,6 +6,17 @@
  */
 export function getTag( el, filter )
 {
+  if (typeof el.tagName !== 'string') {
+    // If the tagName attribute has been overridden, we should 
+    // return null and not use tagName for selector generation.
+    //
+    // This can happen when a <form> element contains an <input>
+    // with an id of `tagName`. In this case, the form element's
+    // tagName property is a reference to the input element, not
+    // a string.
+    return null;
+  }
+
   const tagName = el.tagName.toLowerCase().replace(/:/g, '\\:')
 
   if (filter && !filter('tag', 'tag', tagName)) {

--- a/src/getTag.js
+++ b/src/getTag.js
@@ -1,3 +1,7 @@
+function isString(value) {
+  return typeof value === 'string';
+}
+
 /**
  * Returns the Tag of the element
  * @param  { Object } element
@@ -6,18 +10,26 @@
  */
 export function getTag( el, filter )
 {
-  if (typeof el.tagName !== 'string') {
-    // If the tagName attribute has been overridden, we should 
-    // return null and not use tagName for selector generation.
-    //
-    // This can happen when a <form> element contains an <input>
-    // with an id of `tagName`. In this case, the form element's
-    // tagName property is a reference to the input element, not
-    // a string.
-    return null;
+  let tagName = el.tagName;
+
+  // If the tagName attribute has been overridden, we should 
+  // check the nodeName property instead. If the nodeName property
+  // is also not a string, we should return null and ignore tagName
+  // for selector generation.
+  //
+  // This can happen when a <form> element contains an <input>
+  // with an id of `tagName`. In this case, the form element's
+  // tagName property is a reference to the input element, not
+  // a string.
+  if (!isString(tagName)) {
+    tagName = el.nodeName;
+
+    if (!isString(tagName)) {
+      return null;
+    }
   }
 
-  const tagName = el.tagName.toLowerCase().replace(/:/g, '\\:')
+  tagName = tagName.toLowerCase().replace(/:/g, '\\:')
 
   if (filter && !filter('tag', 'tag', tagName)) {
     return null;

--- a/test/unique-selector.js
+++ b/test/unique-selector.js
@@ -112,7 +112,6 @@ describe( 'Unique Selector Tests', () =>
     expect( uniqueSelector ).to.equal( 'span' );
   } );
 
-
   it( 'Tag', () =>
   {
     $( 'body' ).append( '<div class="test5"><span></span></div><div class="test5"><span></span></div>' );
@@ -127,6 +126,35 @@ describe( 'Unique Selector Tests', () =>
     const findNode = $( '.test5' ).find( 'a' ).get( 0 );
     const uniqueSelector = unique( findNode );
     expect( uniqueSelector ).to.equal( 'a' );
+  } );
+
+  it( 'Tag - filtered due to property override', () =>
+  {
+    $( 'body' ).append(`
+      <div class="test2">
+        <form action="" method="get">
+          <div class="form-example">
+            <label for="name">Enter your name: </label>
+            <input type="text" name="name" id="tagName" required />
+          </div>
+        </form>
+      </div>
+    `);
+
+    const formNode = $( 'form' ).get( 0 );
+
+    // JSDOM doesn't actually exhibit this behavior;
+    // forcing the test to behave as a browser does.
+    Object.defineProperty(formNode, 'tagName', {
+      get: () => {
+        return $( 'input#tagName' ).get( 0 );
+      }
+    })
+
+    expect(typeof formNode.tagName).to.not.equal('string')
+
+    const uniqueSelector = unique( formNode );
+    expect( uniqueSelector ).to.equal( '.test2 > :nth-child(1)' );
   } );
 
   it( 'Attributes', () =>

--- a/test/unique-selector.js
+++ b/test/unique-selector.js
@@ -128,7 +128,7 @@ describe( 'Unique Selector Tests', () =>
     expect( uniqueSelector ).to.equal( 'a' );
   } );
 
-  it( 'Tag - filtered due to property override', () =>
+  it( 'Tag - fallback to nodeName', () =>
   {
     $( 'body' ).append(`
       <div class="test2">
@@ -154,8 +154,47 @@ describe( 'Unique Selector Tests', () =>
     expect(typeof formNode.tagName).to.not.equal('string')
 
     const uniqueSelector = unique( formNode );
-    expect( uniqueSelector ).to.equal( '.test2 > :nth-child(1)' );
+    // nodeName === 'form'
+    expect( uniqueSelector ).to.equal( 'form' );
   } );
+
+  it( 'Tag - ignored due to property override', () =>
+    {
+      $( 'body' ).append(`
+        <div class="test2">
+          <form action="" method="get">
+            <div class="form-example">
+              <label for="name">Enter your name: </label>
+              <input type="text" name="name" id="tagName" required />
+            </div>
+          </form>
+        </div>
+      `);
+  
+      const formNode = $( 'form' ).get( 0 );
+  
+      // JSDOM doesn't actually exhibit this behavior;
+      // forcing the test to behave as a browser does.
+      Object.defineProperty(formNode, 'tagName', {
+        get: () => {
+          return $( 'input#tagName' ).get( 0 );
+        }
+      })
+      Object.defineProperty(formNode, 'nodeName', {
+        get: () => {
+          return $( 'input#tagName' ).get( 0 );
+        }
+      })
+  
+      expect(typeof formNode.tagName).to.not.equal('string')
+      expect(typeof formNode.nodeName).to.not.equal('string')
+
+      const uniqueSelector = unique( formNode );
+      // with nodeName overridden, the isElement check will fail
+      // and the wildcard selector is returned for that element.
+      // This really shouldn't happen in practice.
+      expect( uniqueSelector ).to.equal( '.test2 > *' );
+  } );  
 
   it( 'Attributes', () =>
   {


### PR DESCRIPTION
Alert: https://cypressio.slack.com/archives/C0614M4DZV5/p1746718971129419

We have a [test case](https://github.com/cypress-io/cypress-services/blob/6ae70f2e92d4a22ac87a6317a7156dc64b369ab8/frontend/packages/test-replay/cypress/e2e/7989-form-with-input-id-tagName.cy.ts#L4) in the cypress-services repo that specifically overrides a form element's `tagName` property using a nested `<input id="tagName">` element. When the form is processed with unique-selector, unique-selector will throw as a result of this overridden property that references an element (rather than the expected string). This is causing a few alerts to come through (and knocking our Cypress reports into a "Processed with errors" state).

So, added a little check to ignore tagName when it's not the expected type.

I looked at the other accessors in use here, and most everything else goes through a `getAttribute` call. I [don't think we can really be exhaustive here without going overboard, but `tagName` overrides are something [the App has run into as well](https://github.com/cypress-io/cypress/issues/8191#issuecomment-2251361071), so we might as well work around it (and keep our own tests happy). If we notice other goofy things happening to elements, we can evaluate further protections.