### PR TITLE
fix: Gracefully return null for detached elements

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -250,7 +250,7 @@ export default function unique( el, options={} ) {
       // to prefix the selector with `:host >` to anchor against the root. This helps
       // address the possibility of a unique path segment not existing before reaching
       // the root.
-      if (!isUniqueSelector && isShadowRoot(el.parentNode)) {
+      if (!isUniqueSelector && el.parentNode && isShadowRoot(el.parentNode)) {
         maybeUniqueSelector = `:host > ${maybeUniqueSelector}`
         isUniqueSelector = isUnique(el, maybeUniqueSelector)
 

--- a/test/unique-selector.js
+++ b/test/unique-selector.js
@@ -487,4 +487,10 @@ describe( 'Unique Selector Tests', () =>
       expect( shadowRoot.querySelectorAll(value)[0]).to.equal( inputs[0] );
     })
   })
+
+  it('should return null for element with no parent', () => {
+    const el = $( 'body' )[0].ownerDocument.createElement('div');
+    const uniqueSelector = unique( el );
+    expect( uniqueSelector ).to.equal( null );
+  })
 } );


### PR DESCRIPTION
Address issue introduced in 2.1.2 where a detached element would generate an error rather than gracefully returning null