### PR TITLE
feat: adding requiredAttributes and related arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,32 @@ Generates a unique CSS selector for the given DOM element.
 
 - **`isUniqueCache`** (Map<String, Boolean>, optional) - Cache to improve performance of repeated uniqueness checks. The caller is responsible for cache invalidation.
 
+- **`requiredAttributes`** (Object, optional) - Specifies attributes that must appear in the generated selector regardless of whether they are needed for uniqueness. When provided, matching attribute selectors are woven into every element's segment of the `>` chain, and ancestors above the unique chain are prepended using descendant combinators.
+
+  This option takes precedence over `selectorTypes` and `filter` for the attributes it names — if an element has a required attribute, its `[attr="value"]` selector will appear in the output even if `filter` would reject that attribute for uniqueness purposes, and even if the attribute is not listed in `selectorTypes`.
+
+  The `requiredAttributes` object has the following shape:
+
+  - **`attributeNames`** (String[]) - The attribute names to inject into the selector (e.g., `['data-component', 'data-cy']`). Exact attribute names only — not patterns or regexes.
+  - **`filter`** (Function, optional) - A filter function with the same signature as the top-level `filter` option, applied independently to control which attribute _values_ are allowed to be injected. Return `false` to skip injection for a given element. This filter is separate from the top-level `filter` and serves a different purpose: the top-level `filter` controls which traits are eligible for building a _unique_ selector, while `requiredAttributes.filter` controls which attribute values are eligible for _injection_.
+  - **`elementCache`** (Map<Element, String|null>, optional) - Cache for per-element required attribute selectors. The caller is responsible for cache invalidation.
+
+  ```javascript
+  unique(element, {
+    requiredAttributes: {
+      attributeNames: ['data-component', 'data-cy'],
+      filter: (type, key, value) => {
+        // Exclude auto-generated component names from injection
+        if (type === 'attribute' && key === 'data-component') {
+          return !value.startsWith('jss-');
+        }
+        return true;
+      },
+      elementCache: new Map(),
+    }
+  });
+  ```
+
 #### Returns
 
 - **String** - A unique CSS selector for the element, or `null` if no unique selector can be generated
@@ -118,6 +144,68 @@ const selector = unique(element, {
 });
 ```
 
+### Required Attributes
+
+Use `requiredAttributes` when you want specific attributes to always appear in the generated selector, regardless of whether they contribute to uniqueness. This is useful when your application uses semantic component attributes (e.g., `data-component`, `data-cy`) that you want reflected in every selector for readability or stability.
+
+```javascript
+// Always include data-component in the selector, even when an ID alone would be unique
+const selector = unique(element, {
+    requiredAttributes: {
+        attributeNames: ['data-component']
+    }
+});
+// '#submit-button' becomes '#submit-button[data-component="PrimaryButton"]'
+// Ancestors with data-component are prepended with descendant combinators:
+// '[data-component="Form"] #submit-button[data-component="PrimaryButton"]'
+```
+
+Required attributes take precedence over `selectorTypes` and `filter`. If an element has a required attribute, it will be injected into the selector even if:
+- The attribute is not listed in `selectorTypes`
+- The top-level `filter` would reject that attribute for uniqueness purposes
+
+```javascript
+// The top-level filter rejects data-component for uniqueness building,
+// but requiredAttributes.filter allows it to still be injected.
+const selector = unique(element, {
+    filter: (type, key) => key !== 'data-component',
+    requiredAttributes: {
+        attributeNames: ['data-component'],
+        // No requiredAttributes.filter — all values are injected
+    }
+});
+// data-component still appears in the output
+```
+
+Use `requiredAttributes.filter` independently to control which attribute _values_ get injected, without affecting how uniqueness is determined:
+
+```javascript
+// Inject data-component only when the value doesn't look auto-generated
+const selector = unique(element, {
+    requiredAttributes: {
+        attributeNames: ['data-component'],
+        filter: (type, key, value) => {
+            if (type === 'attribute' && key === 'data-component') {
+                return !value.startsWith('jss-');
+            }
+            return true;
+        },
+        elementCache: new Map(), // reuse across calls for performance
+    }
+});
+```
+
+When multiple `attributeNames` are specified, each is matched independently on every element:
+
+```javascript
+const selector = unique(element, {
+    requiredAttributes: {
+        attributeNames: ['data-cy', 'data-region']
+    }
+});
+// '[data-region="main"] [data-cy="dashboard"] .widget[data-cy="widget-a"]'
+```
+
 ### Performance Optimization with Caching
 
 ```javascript
@@ -157,6 +245,7 @@ The library follows this strategy to generate unique selectors:
 3. **Selector type precedence**: Uses the `selectorTypes` array to determine which selector types to try first
 4. **Combination fallback**: For classes and attributes, tries combinations of multiple selectors if single selectors aren't unique
 5. **Nth-child fallback**: Uses nth-child positioning as a last resort
+6. **Required attribute injection**: After the unique `>` chain is determined, any `requiredAttributes` are woven into each element's segment of the chain. Ancestors above the chain that carry a required attribute are prepended as descendant combinators. Required attributes are injected even when they are not needed for uniqueness and even when the top-level `filter` would exclude them from consideration.
 
 ## Examples of Generated Selectors
 

--- a/README.md
+++ b/README.md
@@ -62,9 +62,9 @@ Generates a unique CSS selector for the given DOM element.
 
   The `requiredAttributes` object has the following shape:
 
-  - **`attributeNames`** (String[]) - The attribute names to inject into the selector (e.g., `['data-component', 'data-cy']`). Exact attribute names only — not patterns or regexes.
-  - **`filter`** (Function, optional) - A filter function with the same signature as the top-level `filter` option, applied independently to control which attribute _values_ are allowed to be injected. Return `false` to skip injection for a given element. This filter is separate from the top-level `filter` and serves a different purpose: the top-level `filter` controls which traits are eligible for building a _unique_ selector, while `requiredAttributes.filter` controls which attribute values are eligible for _injection_.
-  - **`elementCache`** (Map<Element, String|null>, optional) - Cache for per-element required attribute selectors. The caller is responsible for cache invalidation.
+  - **`attributeNames`** (String[]) - The attribute names to inject into the selector (e.g., `['data-component', 'data-cy']`). Exact attribute names only — not patterns or regexes. Names are used as-provided in the generated selector with no internal normalization, so the casing you supply is the casing that appears in the output. When an attribute in `attributeNames` is already present in the base selector (from `selectorTypes`), dedup detection is case-insensitive, so duplicate injection is correctly suppressed regardless of case differences.
+  - **`filter`** (Function, optional) - A filter function with the same signature as the top-level `filter` option, applied independently to control which attribute _values_ are allowed to be injected. Return `false` to skip injection for a given element. This filter is separate from the top-level `filter` and serves a different purpose: the top-level `filter` controls which traits are eligible for building a _unique_ selector, while `requiredAttributes.filter` controls which attribute values are eligible for _injection_. The `key` argument passed to this function will match the casing of the name as provided in `attributeNames`.
+  - **`elementCache`** (Map<Element, (string|null)[]>, optional) - Cache for per-element required attribute selectors. Each cached entry is an array of individual selector strings parallel to `attributeNames` (null for attributes not present or filtered out). The caller is responsible for cache invalidation.
 
   ```javascript
   unique(element, {

--- a/src/getAttribute.js
+++ b/src/getAttribute.js
@@ -1,3 +1,5 @@
+import { escapeAttributeValue } from './utils'
+
 /**
  * Returns the {attr} selector of the element
  * @param  { Element } el - The element.
@@ -15,7 +17,7 @@ export const getAttributeSelector = ( el, attribute, filter ) =>
 
   if (attributeValue) {
     // if we have value that needs quotes
-    return `[${attribute}="${attributeValue}"]`;
+    return `[${attribute}="${escapeAttributeValue(attributeValue)}"]`;
   }
 
   return `[${attribute}]`;

--- a/src/getAttributes.js
+++ b/src/getAttributes.js
@@ -1,3 +1,5 @@
+import { escapeAttributeValue } from './utils'
+
 /**
  * Returns the Attribute selectors of the element
  * @param  { Element } element
@@ -14,7 +16,7 @@ export function getAttributes( el, attributesToIgnore = ['id', 'class', 'length'
   {
     if ( ! ( attributesToIgnore.indexOf( next.nodeName ) > -1 ) && (!filter || filter('attribute', next.nodeName, next.value)) )
     {
-      sum.push( `[${next.nodeName}="${next.value}"]` );
+      sum.push( `[${next.nodeName}="${escapeAttributeValue(next.value)}"]` );
     }
     return sum;
   }, [] );

--- a/src/getName.js
+++ b/src/getName.js
@@ -1,3 +1,5 @@
+import { escapeAttributeValue } from './utils'
+
 /**
  * Returns the `name` attribute of the element (if one exists)
  * @param  { Object } element
@@ -10,7 +12,7 @@ export function getName( el, filter )
 
   if( name !== null && name !== '' && (!filter || filter('attribute', 'name', name)))
   {
-    return `[name="${name}"]`;
+    return `[name="${escapeAttributeValue(name)}"]`;
   }
   return null;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,7 @@ import { isUnique } from './isUnique';
 import { getParents } from './getParents';
 import { getAttributeSelector } from './getAttribute';
 import { isShadowRoot } from './isShadowRoot';
+import { escapeAttributeValue } from './utils';
 
 const dataRegex = /^data-.+/;
 const attrRegex = /^attribute:(.+)/m;
@@ -40,7 +41,7 @@ function getRequiredAttributeSelector(el, compiledAttrs, filter) {
     if (attrValue === null) continue;
     if (filter && !filter('attribute', attributeName, attrValue)) continue;
     matchingSelectors.push(
-      attrValue ? `[${attributeName}="${attrValue}"]` : `[${attributeName}]`
+      attrValue ? `[${attributeName}="${escapeAttributeValue(attrValue)}"]` : `[${attributeName}]`
     );
   }
   return matchingSelectors.length > 0 ? matchingSelectors.join('') : null;
@@ -303,7 +304,8 @@ export default function unique( el, options={} ) {
           // Matches [attrName=  or [attrName]  — used to detect if the attribute is already present in a selector string.
           dedupPattern: new RegExp('\\[' + escaped + '[=\\]]'),
           // Matches [attrName="any-value"] or [attrName] — used to strip an existing attribute bracket before re-appending it.
-          stripPattern: new RegExp('\\[' + escaped + '(?:="[^"]*")?\\]'),
+          // The value pattern (?:[^"\\]|\\.)*  handles CSS-escaped characters (e.g. \", \\, \A ) correctly.
+          stripPattern: new RegExp('\\[' + escaped + '(?:="(?:[^"\\\\]|\\\\.)*")?\\]'),
         };
       })
     : null;

--- a/src/index.js
+++ b/src/index.js
@@ -18,6 +18,152 @@ const dataRegex = /^data-.+/;
 const attrRegex = /^attribute:(.+)/m;
 
 /**
+ * Checks if an element has any attributes matching the requiredAttributes config.
+ * @param { Element } el
+ * @param { Array<{attributeName: string, value: string}> } requiredAttributes
+ * @return { String | null } - Combined attribute selector string, or null if no match
+ */
+function getRequiredAttributeSelector(el, requiredAttributes) {
+  const matchingSelectors = [];
+  for (const { attributeName, value } of requiredAttributes) {
+    const attrValue = el.getAttribute(attributeName);
+    if (attrValue === null) continue;
+    const regex = new RegExp(value);
+    if (regex.test(attrValue)) {
+      matchingSelectors.push(
+        attrValue ? `[${attributeName}="${attrValue}"]` : `[${attributeName}]`
+      );
+    }
+  }
+  return matchingSelectors.length > 0 ? matchingSelectors.join('') : null;
+}
+
+/**
+ * Returns the cached required attribute selector for an element, or computes and caches it.
+ * @param { Element } el
+ * @param { Array<{attributeName: string, value: string}> } requiredAttributes
+ * @param { Map | undefined } cache
+ * @return { String | null }
+ */
+function getCachedRequiredAttr(el, requiredAttributes, cache) {
+  if (cache && cache.has(el)) return cache.get(el);
+  const selector = getRequiredAttributeSelector(el, requiredAttributes);
+  if (cache) cache.set(el, selector);
+  return selector;
+}
+
+/**
+ * Inserts a required attribute selector into an element selector, placing it before any :nth-child.
+ * @param { String } selector - A single element's selector (no combinators)
+ * @param { String } attrSelector
+ * @return { String }
+ */
+function insertRequiredAttrIntoSelector(selector, attrSelector) {
+  // Extract the attribute name from attrSelector (e.g. "data-cy" from '[data-cy="val"]')
+  const attrName = attrSelector.slice(1, attrSelector.indexOf(']')).split('=')[0];
+  // Check if the selector already contains an attribute selector for this name,
+  // matching a literal "[attrName=" or "[attrName]" — not inside a quoted value.
+  const attrPattern = new RegExp('\\[' + attrName.replace(/[-[\]/{}()*+?.\\^$|]/g, '\\$&') + '[=\\]]');
+  if (attrPattern.test(selector)) {
+    return selector;
+  }
+  const nthChildIndex = selector.indexOf(':nth-child');
+  if (nthChildIndex !== -1) {
+    const before = selector.slice(0, nthChildIndex);
+    const nthPart = selector.slice(nthChildIndex);
+    return before + attrSelector + nthPart;
+  }
+  return selector + attrSelector;
+}
+
+/**
+ * Builds a selector that includes all required attribute matches from the element and its ancestors.
+ * Replicates the unique() walk but weaves required attributes into each element's selector
+ * as the chain is built, ensuring attrs on elements within the > chain are appended to their
+ * segment rather than prepended as separate ancestors.
+ * @param { Element } el
+ * @param { Object } options - The full options object passed to unique()
+ * @return { String | null }
+ */
+function buildRequiredAttributesSelector(el, options) {
+  const {
+    selectorTypes: sTypes = ['id', 'name', 'class', 'tag', 'nth-child'],
+    attributesToIgnore: aToIgnore = ['id', 'class', 'length'],
+    filter,
+    selectorCache,
+    isUniqueCache,
+    requiredAttributes,
+    requiredAttributesCache,
+  } = options;
+
+  const normalizedFilter = filter && function(type, key, value) {
+    const result = filter(type, key, value);
+    if (result === null || result === undefined) return true;
+    return result;
+  };
+
+  // Walk up from el building the selector chain (like unique() does)
+  // but append required attributes to each element's selector inline.
+  const allSelectors = [];
+  const chainElements = [];
+  let currentElement = el;
+
+  while (currentElement) {
+    let selector = selectorCache ? selectorCache.get(currentElement) : undefined;
+
+    if (!selector) {
+      selector = getUniqueSelector(currentElement, sTypes, aToIgnore, normalizedFilter);
+      if (selectorCache) selectorCache.set(currentElement, selector);
+    }
+
+    // Weave required attribute into this element's selector
+    const reqAttr = getCachedRequiredAttr(currentElement, requiredAttributes, requiredAttributesCache);
+    const decoratedSelector = reqAttr
+      ? insertRequiredAttrIntoSelector(selector, reqAttr)
+      : selector;
+
+    allSelectors.unshift(decoratedSelector);
+    chainElements.unshift(currentElement);
+
+    var maybeUniqueSelector = allSelectors.join(' > ');
+    var isUniqueResult = isUniqueCache ? isUniqueCache.get(maybeUniqueSelector) : undefined;
+    if (isUniqueResult === undefined) {
+      isUniqueResult = isUnique(el, maybeUniqueSelector);
+      if (isUniqueCache) isUniqueCache.set(maybeUniqueSelector, isUniqueResult);
+
+      if (!isUniqueResult && el.parentNode && isShadowRoot(el.parentNode)) {
+        maybeUniqueSelector = ':host > ' + maybeUniqueSelector;
+        isUniqueResult = isUnique(el, maybeUniqueSelector);
+        if (isUniqueCache) isUniqueCache.set(maybeUniqueSelector, isUniqueResult);
+      }
+    }
+
+    if (isUniqueResult) {
+      // Found a unique chain. Now collect any ancestors ABOVE the chain
+      // that have matching required attributes, prepend with descendant combinators.
+      var ancestorSelectors = [];
+      var ancestor = currentElement.parentElement;
+      while (ancestor) {
+        var ancestorReqAttr = getCachedRequiredAttr(ancestor, requiredAttributes, requiredAttributesCache);
+        if (ancestorReqAttr) {
+          ancestorSelectors.unshift(ancestorReqAttr);
+        }
+        ancestor = ancestor.parentElement;
+      }
+
+      if (ancestorSelectors.length > 0) {
+        return ancestorSelectors.join(' ') + ' ' + maybeUniqueSelector;
+      }
+      return maybeUniqueSelector;
+    }
+
+    currentElement = currentElement.parentElement;
+  }
+
+  return null;
+}
+
+/**
  * @typedef Filter
  * @type {Function}
  * @param {string} type - the trait being considered ('attribute', 'tag', 'nth-child'). As a special case, the `class` attribute is split on whitespace and each token passed individually with a `class` type.
@@ -204,13 +350,19 @@ function getUniqueSelector( element, selectorTypes, attributesToIgnore, filter )
  * @api private
  */
 export default function unique( el, options={} ) {
-  const { 
-    selectorTypes=['id', 'name', 'class', 'tag', 'nth-child'], 
+  const {
+    selectorTypes=['id', 'name', 'class', 'tag', 'nth-child'],
     attributesToIgnore= ['id', 'class', 'length'],
     filter,
     selectorCache,
-    isUniqueCache
+    isUniqueCache,
+    requiredAttributes,
+    requiredAttributesCache,
   } = options;
+
+  if (requiredAttributes && requiredAttributes.length > 0) {
+    return buildRequiredAttributesSelector(el, options);
+  }
   // If filter was provided wrap it to ensure a default value of `true` is returned if the provided function fails to return a value
   const normalizedFilter = filter && function(type, key, value) {
     const result = filter(type, key, value)

--- a/src/index.js
+++ b/src/index.js
@@ -288,8 +288,8 @@ export default function unique( el, options={} ) {
 
   const {
     attributeNames: requiredAttributeNames,
-    filter: reqFilter,
-    elementCache: reqCache,
+    filter: requiredAttributesFilter,
+    elementCache: requiredAttributesElementCache,
   } = requiredAttributes || {};
 
   // Precompile required attribute patterns once per call to avoid repeated
@@ -302,7 +302,8 @@ export default function unique( el, options={} ) {
         return {
           attributeName,
           // Matches [attrName=  or [attrName]  — used to detect if the attribute is already present in a selector string.
-          dedupPattern: new RegExp('\\[' + escaped + '[=\\]]'),
+          // Case-insensitive so it catches any casing the base selector builder may have used for the attribute name.
+          dedupPattern: new RegExp('\\[' + escaped + '[=\\]]', 'i'),
           // Matches [attrName="any-value"] or [attrName] — used to strip an existing attribute bracket before re-appending it.
           // The value pattern (?:[^"\\]|\\.)*  handles CSS-escaped characters (e.g. \", \\, \A ) correctly.
           stripPattern: new RegExp('\\[' + escaped + '(?:="(?:[^"\\\\]|\\\\.)*")?\\]'),
@@ -334,9 +335,9 @@ export default function unique( el, options={} ) {
 
       // Merge any matching required attributes into the element's selector
       if (hasRequiredAttrs) {
-        const reqAttr = getCachedRequiredAttr(currentElement, compiledRequiredAttrs, reqFilter, reqCache);
-        if (reqAttr) {
-          selector = insertRequiredAttrIntoSelector(selector, reqAttr, compiledRequiredAttrs);
+        const elementRequiredAttributes = getCachedRequiredAttr(currentElement, compiledRequiredAttrs, requiredAttributesFilter, requiredAttributesElementCache);
+        if (elementRequiredAttributes) {
+          selector = insertRequiredAttrIntoSelector(selector, elementRequiredAttributes, compiledRequiredAttrs);
         }
       }
 
@@ -375,7 +376,7 @@ export default function unique( el, options={} ) {
         const ancestorSelectors = [];
         let ancestor = currentElement.parentElement;
         while (ancestor) {
-          const ancestorReqAttr = getCachedRequiredAttr(ancestor, compiledRequiredAttrs, reqFilter, reqCache);
+          const ancestorReqAttr = getCachedRequiredAttr(ancestor, compiledRequiredAttrs, requiredAttributesFilter, requiredAttributesElementCache);
           if (ancestorReqAttr) {
             ancestorSelectors.unshift(ancestorReqAttr);
           }

--- a/src/index.js
+++ b/src/index.js
@@ -18,17 +18,25 @@ const dataRegex = /^data-.+/;
 const attrRegex = /^attribute:(.+)/m;
 
 /**
- * Checks if an element has any attributes matching the requiredAttributes config.
- * @param { Element } el
- * @param { Array<{attributeName: string, value: string}> } requiredAttributes
- * @return { String | null } - Combined attribute selector string, or null if no match
+ * @typedef CompiledRequiredAttr
+ * @property { string } attributeName - The DOM attribute name (e.g. 'data-cy')
+ * @property { RegExp } regex - Precompiled pattern to test attribute values against
+ * @property { RegExp } dedupPattern - Matches `[attrName=` or `[attrName]` in a selector string to detect existing usage
+ * @property { RegExp } stripPattern - Matches a full `[attrName="..."]` or `[attrName]` bracket for removal during dedup
  */
-function getRequiredAttributeSelector(el, requiredAttributes) {
+
+/**
+ * Builds a combined attribute selector string for all required attributes present on an element.
+ * For example, an element with data-cy="nav" and data-test="main" might produce '[data-cy="nav"][data-test="main"]'.
+ * @param { Element } el
+ * @param { CompiledRequiredAttr[] } compiledAttrs
+ * @return { String | null }
+ */
+function getRequiredAttributeSelector(el, compiledAttrs) {
   const matchingSelectors = [];
-  for (const { attributeName, value } of requiredAttributes) {
+  for (const { attributeName, regex } of compiledAttrs) {
     const attrValue = el.getAttribute(attributeName);
     if (attrValue === null) continue;
-    const regex = new RegExp(value);
     if (regex.test(attrValue)) {
       matchingSelectors.push(
         attrValue ? `[${attributeName}="${attrValue}"]` : `[${attributeName}]`
@@ -39,128 +47,45 @@ function getRequiredAttributeSelector(el, requiredAttributes) {
 }
 
 /**
- * Returns the cached required attribute selector for an element, or computes and caches it.
+ * Returns the required attribute selector for an element, using the cache when available.
  * @param { Element } el
- * @param { Array<{attributeName: string, value: string}> } requiredAttributes
- * @param { Map | undefined } cache
+ * @param { CompiledRequiredAttr[] } compiledAttrs
+ * @param { Map<Element, String|null> | undefined } cache
  * @return { String | null }
  */
-function getCachedRequiredAttr(el, requiredAttributes, cache) {
+function getCachedRequiredAttr(el, compiledAttrs, cache) {
   if (cache && cache.has(el)) return cache.get(el);
-  const selector = getRequiredAttributeSelector(el, requiredAttributes);
+  const selector = getRequiredAttributeSelector(el, compiledAttrs);
   if (cache) cache.set(el, selector);
   return selector;
 }
 
 /**
- * Inserts a required attribute selector into an element selector, placing it before any :nth-child.
+ * Merges a required attribute selector into an element's base selector, placing it
+ * before any :nth-child pseudo-class. Attributes already present in the base selector
+ * (e.g. because selectorTypes also matched them) are skipped to avoid duplicates.
  * @param { String } selector - A single element's selector (no combinators)
- * @param { String } attrSelector
+ * @param { String } attrSelector - Combined required attribute selector (e.g. '[data-cy="val"]')
+ * @param { CompiledRequiredAttr[] } compiledAttrs
  * @return { String }
  */
-function insertRequiredAttrIntoSelector(selector, attrSelector) {
-  // Extract the attribute name from attrSelector (e.g. "data-cy" from '[data-cy="val"]')
-  const attrName = attrSelector.slice(1, attrSelector.indexOf(']')).split('=')[0];
-  // Check if the selector already contains an attribute selector for this name,
-  // matching a literal "[attrName=" or "[attrName]" — not inside a quoted value.
-  const attrPattern = new RegExp('\\[' + attrName.replace(/[-[\]/{}()*+?.\\^$|]/g, '\\$&') + '[=\\]]');
-  if (attrPattern.test(selector)) {
+function insertRequiredAttrIntoSelector(selector, attrSelector, compiledAttrs) {
+  // Strip any attributes that already appear in the base selector
+  let toInsert = attrSelector;
+  for (const { dedupPattern, stripPattern } of compiledAttrs) {
+    if (dedupPattern.test(selector)) {
+      toInsert = toInsert.replace(stripPattern, '');
+    }
+  }
+  if (!toInsert) {
     return selector;
   }
+  // Insert before :nth-child so the attribute qualifier binds to the element tag/class
   const nthChildIndex = selector.indexOf(':nth-child');
   if (nthChildIndex !== -1) {
-    const before = selector.slice(0, nthChildIndex);
-    const nthPart = selector.slice(nthChildIndex);
-    return before + attrSelector + nthPart;
+    return selector.slice(0, nthChildIndex) + toInsert + selector.slice(nthChildIndex);
   }
-  return selector + attrSelector;
-}
-
-/**
- * Builds a selector that includes all required attribute matches from the element and its ancestors.
- * Replicates the unique() walk but weaves required attributes into each element's selector
- * as the chain is built, ensuring attrs on elements within the > chain are appended to their
- * segment rather than prepended as separate ancestors.
- * @param { Element } el
- * @param { Object } options - The full options object passed to unique()
- * @return { String | null }
- */
-function buildRequiredAttributesSelector(el, options) {
-  const {
-    selectorTypes: sTypes = ['id', 'name', 'class', 'tag', 'nth-child'],
-    attributesToIgnore: aToIgnore = ['id', 'class', 'length'],
-    filter,
-    selectorCache,
-    isUniqueCache,
-    requiredAttributes,
-    requiredAttributesCache,
-  } = options;
-
-  const normalizedFilter = filter && function(type, key, value) {
-    const result = filter(type, key, value);
-    if (result === null || result === undefined) return true;
-    return result;
-  };
-
-  // Walk up from el building the selector chain (like unique() does)
-  // but append required attributes to each element's selector inline.
-  const allSelectors = [];
-  const chainElements = [];
-  let currentElement = el;
-
-  while (currentElement) {
-    let selector = selectorCache ? selectorCache.get(currentElement) : undefined;
-
-    if (!selector) {
-      selector = getUniqueSelector(currentElement, sTypes, aToIgnore, normalizedFilter);
-      if (selectorCache) selectorCache.set(currentElement, selector);
-    }
-
-    // Weave required attribute into this element's selector
-    const reqAttr = getCachedRequiredAttr(currentElement, requiredAttributes, requiredAttributesCache);
-    const decoratedSelector = reqAttr
-      ? insertRequiredAttrIntoSelector(selector, reqAttr)
-      : selector;
-
-    allSelectors.unshift(decoratedSelector);
-    chainElements.unshift(currentElement);
-
-    var maybeUniqueSelector = allSelectors.join(' > ');
-    var isUniqueResult = isUniqueCache ? isUniqueCache.get(maybeUniqueSelector) : undefined;
-    if (isUniqueResult === undefined) {
-      isUniqueResult = isUnique(el, maybeUniqueSelector);
-      if (isUniqueCache) isUniqueCache.set(maybeUniqueSelector, isUniqueResult);
-
-      if (!isUniqueResult && el.parentNode && isShadowRoot(el.parentNode)) {
-        maybeUniqueSelector = ':host > ' + maybeUniqueSelector;
-        isUniqueResult = isUnique(el, maybeUniqueSelector);
-        if (isUniqueCache) isUniqueCache.set(maybeUniqueSelector, isUniqueResult);
-      }
-    }
-
-    if (isUniqueResult) {
-      // Found a unique chain. Now collect any ancestors ABOVE the chain
-      // that have matching required attributes, prepend with descendant combinators.
-      var ancestorSelectors = [];
-      var ancestor = currentElement.parentElement;
-      while (ancestor) {
-        var ancestorReqAttr = getCachedRequiredAttr(ancestor, requiredAttributes, requiredAttributesCache);
-        if (ancestorReqAttr) {
-          ancestorSelectors.unshift(ancestorReqAttr);
-        }
-        ancestor = ancestor.parentElement;
-      }
-
-      if (ancestorSelectors.length > 0) {
-        return ancestorSelectors.join(' ') + ' ' + maybeUniqueSelector;
-      }
-      return maybeUniqueSelector;
-    }
-
-    currentElement = currentElement.parentElement;
-  }
-
-  return null;
+  return selector + toInsert;
 }
 
 /**
@@ -335,8 +260,8 @@ function getUniqueSelector( element, selectorTypes, attributesToIgnore, filter )
 }
 
 /**
- * Generate unique CSS selector for given DOM element. Selector uniqueness is determined based on the given element's root node. 
- * Elements rendered within Shadow DOM will derive a selector that is unique within the associated ShadowRoot context. 
+ * Generate unique CSS selector for given DOM element. Selector uniqueness is determined based on the given element's root node.
+ * Elements rendered within Shadow DOM will derive a selector that is unique within the associated ShadowRoot context.
  * Otherwise, a selector that is unique within the element's owning document will be derived.
  *
  * @param {Element} el
@@ -344,10 +269,11 @@ function getUniqueSelector( element, selectorTypes, attributesToIgnore, filter )
  * @param {String[]} options.selectorTypes Specify the set of traits to leverage when building selectors in precedence order
  * @param {String[]} options.attributesToIgnore Specify a set of attributes to *not* leverage when building selectors
  * @param {Filter} options.filter Provide a filter function to conditionally reject various traits when building selectors.
- * @param {Map<Element, String>} options.selectorCache Provide a cache to improve performance of repeated selector generation - it is the responsibility of the caller to handle cache invalidation. Caching is performed using the input Element as key. This cache handles Element -> Selector caching.
- * @param {Map<String, Boolean>} options.isUniqueCache Provide a cache to improve performance of repeated selector generation - it is the responsibility of the caller to handle cache invalidation. Caching is performed using the input Element as key. This cache handles Selector -> isUnique caching.
+ * @param {Map<Element, String>} options.selectorCache Cache for Element -> Selector mappings. Caller is responsible for invalidation.
+ * @param {Map<String, Boolean>} options.isUniqueCache Cache for Selector -> isUnique mappings. Caller is responsible for invalidation.
+ * @param {Array<{attributeName: string, value: string}>} options.requiredAttributes Attribute patterns that must appear in the generated selector. Each entry specifies an attribute name and a regex pattern to match its value. Matching attributes are woven into the selector chain and ancestor context.
+ * @param {Map<Element, String|null>} options.requiredAttributesCache Cache for Element -> required attribute selector mappings. Caller is responsible for invalidation.
  * @return {String}
- * @api private
  */
 export default function unique( el, options={} ) {
   const {
@@ -360,10 +286,22 @@ export default function unique( el, options={} ) {
     requiredAttributesCache,
   } = options;
 
-  if (requiredAttributes && requiredAttributes.length > 0) {
-    return buildRequiredAttributesSelector(el, options);
-  }
-  // If filter was provided wrap it to ensure a default value of `true` is returned if the provided function fails to return a value
+  // Precompile requiredAttributes regex patterns once per call to avoid
+  // repeated RegExp construction during the element walk.
+  const hasRequiredAttrs = requiredAttributes && requiredAttributes.length > 0;
+  const compiledRequiredAttrs = hasRequiredAttrs
+    ? requiredAttributes.map(({ attributeName, value }) => {
+        const escaped = attributeName.replace(/[-[\]/{}()*+?.\\^$|]/g, '\\$&');
+        return {
+          attributeName,
+          regex: new RegExp(value),
+          dedupPattern: new RegExp('\\[' + escaped + '[=\\]]'),
+          stripPattern: new RegExp('\\[' + escaped + '(?:="[^"]*")?\\]'),
+        };
+      })
+    : null;
+
+  // Wrap filter to default to `true` when the provided function returns null/undefined
   const normalizedFilter = filter && function(type, key, value) {
     const result = filter(type, key, value)
     if (result === null || result === undefined) {
@@ -384,10 +322,19 @@ export default function unique( el, options={} ) {
         attributesToIgnore,
         normalizedFilter
       )
+
+      // Merge any matching required attributes into the element's selector
+      if (hasRequiredAttrs) {
+        const reqAttr = getCachedRequiredAttr(currentElement, compiledRequiredAttrs, requiredAttributesCache);
+        if (reqAttr) {
+          selector = insertRequiredAttrIntoSelector(selector, reqAttr, compiledRequiredAttrs);
+        }
+      }
+
       if (selectorCache) {
         selectorCache.set(currentElement, selector)
-       }
-     }
+      }
+    }
 
     allSelectors.unshift(selector)
     let maybeUniqueSelector = allSelectors.join(' > ')
@@ -413,6 +360,23 @@ export default function unique( el, options={} ) {
     }
 
     if (isUniqueSelector) {
+      // Prepend required attribute selectors from ancestors above the unique
+      // chain using descendant combinators (e.g. '[data-cy="app"] [data-cy="nav"] .btn').
+      if (hasRequiredAttrs) {
+        const ancestorSelectors = [];
+        let ancestor = currentElement.parentElement;
+        while (ancestor) {
+          const ancestorReqAttr = getCachedRequiredAttr(ancestor, compiledRequiredAttrs, requiredAttributesCache);
+          if (ancestorReqAttr) {
+            ancestorSelectors.unshift(ancestorReqAttr);
+          }
+          ancestor = ancestor.parentElement;
+        }
+        if (ancestorSelectors.length > 0) {
+          return ancestorSelectors.join(' ') + ' ' + maybeUniqueSelector;
+        }
+      }
+
       return maybeUniqueSelector
     }
 

--- a/src/index.js
+++ b/src/index.js
@@ -291,11 +291,14 @@ export default function unique( el, options={} ) {
   const hasRequiredAttrs = requiredAttributes && requiredAttributes.length > 0;
   const compiledRequiredAttrs = hasRequiredAttrs
     ? requiredAttributes.map(({ attributeName, value }) => {
+        // Escape regex metacharacters: - [ ] / { } ( ) * + ? . \ ^ $ |
         const escaped = attributeName.replace(/[-[\]/{}()*+?.\\^$|]/g, '\\$&');
         return {
           attributeName,
           regex: (!value || value === '.*') ? null : new RegExp(value),
+          // Matches [attrName=  or [attrName]  — used to detect if the attribute is already present in a selector string.
           dedupPattern: new RegExp('\\[' + escaped + '[=\\]]'),
+          // Matches [attrName="any-value"] or [attrName] — used to strip an existing attribute bracket before re-appending it.
           stripPattern: new RegExp('\\[' + escaped + '(?:="[^"]*")?\\]'),
         };
       })

--- a/src/index.js
+++ b/src/index.js
@@ -21,73 +21,63 @@ const attrRegex = /^attribute:(.+)/m;
 /**
  * @typedef CompiledRequiredAttr
  * @property { string } attributeName - The DOM attribute name (e.g. 'data-cy')
- * @property { RegExp } dedupPattern - Matches `[attrName=` or `[attrName]` in a selector string to detect existing usage
- * @property { RegExp } stripPattern - Matches a full `[attrName="..."]` or `[attrName]` bracket for removal during dedup
+ * @property { RegExp } dedupPattern - Matches `[attrName=` or `[attrName]` in a selector string to detect existing usage.
+ *   Case-insensitive so it catches any casing the base selector builder may have used for the attribute name.
  */
 
 /**
- * Builds a combined attribute selector string for all required attributes present on an element.
- * An optional filter function (sourced independently from the main selector filter) controls which
- * attribute values are allowed to be injected.
+ * Returns per-attribute selector strings for all required attributes on an element.
+ * Each entry in the returned array corresponds to the same-index entry in compiledAttrs:
+ * a `[attr="value"]` string if the attribute is present and passes the filter, otherwise null.
  * @param { Element } el
  * @param { CompiledRequiredAttr[] } compiledAttrs
  * @param { Function | undefined } filter
- * @return { String | null }
+ * @return { (string|null)[] }
  */
-function getRequiredAttributeSelector(el, compiledAttrs, filter) {
-  const matchingSelectors = [];
-  for (const { attributeName } of compiledAttrs) {
+function getPerAttrSelectors(el, compiledAttrs, filter) {
+  return compiledAttrs.map(({ attributeName }) => {
     const attrValue = el.getAttribute(attributeName);
-    if (attrValue === null) continue;
-    if (filter && !filter('attribute', attributeName, attrValue)) continue;
-    matchingSelectors.push(
-      attrValue ? `[${attributeName}="${escapeAttributeValue(attrValue)}"]` : `[${attributeName}]`
-    );
-  }
-  return matchingSelectors.length > 0 ? matchingSelectors.join('') : null;
+    if (attrValue === null) return null;
+    if (filter && !filter('attribute', attributeName, attrValue)) return null;
+    return attrValue ? `[${attributeName}="${escapeAttributeValue(attrValue)}"]` : `[${attributeName}]`;
+  });
 }
 
 /**
- * Returns the required attribute selector for an element, using the cache when available.
+ * Returns per-attribute selectors for an element, using the cache when available.
  * @param { Element } el
  * @param { CompiledRequiredAttr[] } compiledAttrs
  * @param { Function | undefined } filter
- * @param { Map<Element, String|null> | undefined } cache
- * @return { String | null }
+ * @param { Map<Element, (string|null)[]> | undefined } cache
+ * @return { (string|null)[] }
  */
-function getCachedRequiredAttr(el, compiledAttrs, filter, cache) {
+function getCachedPerAttrSelectors(el, compiledAttrs, filter, cache) {
   if (cache && cache.has(el)) return cache.get(el);
-  const selector = getRequiredAttributeSelector(el, compiledAttrs, filter);
-  if (cache) cache.set(el, selector);
-  return selector;
+  const selectors = getPerAttrSelectors(el, compiledAttrs, filter);
+  if (cache) cache.set(el, selectors);
+  return selectors;
 }
 
 /**
- * Merges a required attribute selector into an element's base selector, placing it
+ * Merges required attribute selectors into an element's base selector, placing them
  * before any :nth-child pseudo-class. Attributes already present in the base selector
- * (e.g. because selectorTypes also matched them) are skipped to avoid duplicates.
+ * are excluded from injection via a case-insensitive dedupPattern check.
  * @param { String } selector - A single element's selector (no combinators)
- * @param { String } attrSelector - Combined required attribute selector (e.g. '[data-cy="val"]')
+ * @param { (string|null)[] } perAttrSelectors - Per-attribute selector strings parallel to compiledAttrs
  * @param { CompiledRequiredAttr[] } compiledAttrs
  * @return { String }
  */
-function insertRequiredAttrIntoSelector(selector, attrSelector, compiledAttrs) {
-  // Strip any attributes that already appear in the base selector
-  let toInsert = attrSelector;
-  for (const { dedupPattern, stripPattern } of compiledAttrs) {
-    if (dedupPattern.test(selector)) {
-      toInsert = toInsert.replace(stripPattern, '');
-    }
-  }
-  if (!toInsert) {
-    return selector;
-  }
+function insertRequiredAttrIntoSelector(selector, perAttrSelectors, compiledAttrs) {
+  const toInject = perAttrSelectors
+    .filter((s, i) => s !== null && !compiledAttrs[i].dedupPattern.test(selector))
+    .join('');
+  if (!toInject) return selector;
   // Insert before :nth-child so the attribute qualifier binds to the element tag/class
   const nthChildIndex = selector.indexOf(':nth-child');
   if (nthChildIndex !== -1) {
-    return selector.slice(0, nthChildIndex) + toInsert + selector.slice(nthChildIndex);
+    return selector.slice(0, nthChildIndex) + toInject + selector.slice(nthChildIndex);
   }
-  return selector + toInsert;
+  return selector + toInject;
 }
 
 /**
@@ -273,7 +263,7 @@ function getUniqueSelector( element, selectorTypes, attributesToIgnore, filter )
  * @param {Filter} options.filter Provide a filter function to conditionally reject various traits when building selectors.
  * @param {Map<Element, String>} options.selectorCache Cache for Element -> Selector mappings. Caller is responsible for invalidation.
  * @param {Map<String, Boolean>} options.isUniqueCache Cache for Selector -> isUnique mappings. Caller is responsible for invalidation.
- * @param {{ attributeNames: string[], filter?: Function, elementCache?: Map<Element, String|null> }} options.requiredAttributes Attributes that must appear in the generated selector. Specifies the attribute names to inject, an optional filter function to control which values are allowed, and an optional element cache. Matching attributes are woven into the selector chain and ancestor context.
+ * @param {{ attributeNames: string[], filter?: Function, elementCache?: Map<Element, (string|null)[]> }} options.requiredAttributes Attributes that must appear in the generated selector. Specifies the attribute names to inject, an optional filter function to control which values are allowed, and an optional element cache. Matching attributes are woven into the selector chain and ancestor context.
  * @return {String}
  */
 export default function unique( el, options={} ) {
@@ -301,12 +291,8 @@ export default function unique( el, options={} ) {
         const escaped = attributeName.replace(/[-[\]/{}()*+?.\\^$|]/g, '\\$&');
         return {
           attributeName,
-          // Matches [attrName=  or [attrName]  — used to detect if the attribute is already present in a selector string.
-          // Case-insensitive so it catches any casing the base selector builder may have used for the attribute name.
+          // Case-insensitive: catches any casing the base selector builder may have used for the attribute name.
           dedupPattern: new RegExp('\\[' + escaped + '[=\\]]', 'i'),
-          // Matches [attrName="any-value"] or [attrName] — used to strip an existing attribute bracket before re-appending it.
-          // The value pattern (?:[^"\\]|\\.)*  handles CSS-escaped characters (e.g. \", \\, \A ) correctly.
-          stripPattern: new RegExp('\\[' + escaped + '(?:="(?:[^"\\\\]|\\\\.)*")?\\]'),
         };
       })
     : null;
@@ -335,10 +321,8 @@ export default function unique( el, options={} ) {
 
       // Merge any matching required attributes into the element's selector
       if (hasRequiredAttrs) {
-        const elementRequiredAttributes = getCachedRequiredAttr(currentElement, compiledRequiredAttrs, requiredAttributesFilter, requiredAttributesElementCache);
-        if (elementRequiredAttributes) {
-          selector = insertRequiredAttrIntoSelector(selector, elementRequiredAttributes, compiledRequiredAttrs);
-        }
+        const perAttrSelectors = getCachedPerAttrSelectors(currentElement, compiledRequiredAttrs, requiredAttributesFilter, requiredAttributesElementCache);
+        selector = insertRequiredAttrIntoSelector(selector, perAttrSelectors, compiledRequiredAttrs);
       }
 
       if (selectorCache) {
@@ -376,10 +360,9 @@ export default function unique( el, options={} ) {
         const ancestorSelectors = [];
         let ancestor = currentElement.parentElement;
         while (ancestor) {
-          const ancestorReqAttr = getCachedRequiredAttr(ancestor, compiledRequiredAttrs, requiredAttributesFilter, requiredAttributesElementCache);
-          if (ancestorReqAttr) {
-            ancestorSelectors.unshift(ancestorReqAttr);
-          }
+          const perAttrSelectors = getCachedPerAttrSelectors(ancestor, compiledRequiredAttrs, requiredAttributesFilter, requiredAttributesElementCache);
+          const combined = perAttrSelectors.filter(Boolean).join('');
+          if (combined) ancestorSelectors.unshift(combined);
           ancestor = ancestor.parentElement;
         }
         if (ancestorSelectors.length > 0) {

--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,7 @@ const attrRegex = /^attribute:(.+)/m;
 /**
  * @typedef CompiledRequiredAttr
  * @property { string } attributeName - The DOM attribute name (e.g. 'data-cy')
- * @property { RegExp } regex - Precompiled pattern to test attribute values against
+ * @property { RegExp | null } regex - Precompiled pattern to test attribute values against; null means match any value
  * @property { RegExp } dedupPattern - Matches `[attrName=` or `[attrName]` in a selector string to detect existing usage
  * @property { RegExp } stripPattern - Matches a full `[attrName="..."]` or `[attrName]` bracket for removal during dedup
  */
@@ -37,7 +37,7 @@ function getRequiredAttributeSelector(el, compiledAttrs) {
   for (const { attributeName, regex } of compiledAttrs) {
     const attrValue = el.getAttribute(attributeName);
     if (attrValue === null) continue;
-    if (regex.test(attrValue)) {
+    if (regex === null || regex.test(attrValue)) {
       matchingSelectors.push(
         attrValue ? `[${attributeName}="${attrValue}"]` : `[${attributeName}]`
       );
@@ -294,7 +294,7 @@ export default function unique( el, options={} ) {
         const escaped = attributeName.replace(/[-[\]/{}()*+?.\\^$|]/g, '\\$&');
         return {
           attributeName,
-          regex: new RegExp(value),
+          regex: (!value || value === '.*') ? null : new RegExp(value),
           dedupPattern: new RegExp('\\[' + escaped + '[=\\]]'),
           stripPattern: new RegExp('\\[' + escaped + '(?:="[^"]*")?\\]'),
         };

--- a/src/index.js
+++ b/src/index.js
@@ -20,28 +20,28 @@ const attrRegex = /^attribute:(.+)/m;
 /**
  * @typedef CompiledRequiredAttr
  * @property { string } attributeName - The DOM attribute name (e.g. 'data-cy')
- * @property { RegExp | null } regex - Precompiled pattern to test attribute values against; null means match any value
  * @property { RegExp } dedupPattern - Matches `[attrName=` or `[attrName]` in a selector string to detect existing usage
  * @property { RegExp } stripPattern - Matches a full `[attrName="..."]` or `[attrName]` bracket for removal during dedup
  */
 
 /**
  * Builds a combined attribute selector string for all required attributes present on an element.
- * For example, an element with data-cy="nav" and data-test="main" might produce '[data-cy="nav"][data-test="main"]'.
+ * An optional filter function (sourced independently from the main selector filter) controls which
+ * attribute values are allowed to be injected.
  * @param { Element } el
  * @param { CompiledRequiredAttr[] } compiledAttrs
+ * @param { Function | undefined } filter
  * @return { String | null }
  */
-function getRequiredAttributeSelector(el, compiledAttrs) {
+function getRequiredAttributeSelector(el, compiledAttrs, filter) {
   const matchingSelectors = [];
-  for (const { attributeName, regex } of compiledAttrs) {
+  for (const { attributeName } of compiledAttrs) {
     const attrValue = el.getAttribute(attributeName);
     if (attrValue === null) continue;
-    if (regex === null || regex.test(attrValue)) {
-      matchingSelectors.push(
-        attrValue ? `[${attributeName}="${attrValue}"]` : `[${attributeName}]`
-      );
-    }
+    if (filter && !filter('attribute', attributeName, attrValue)) continue;
+    matchingSelectors.push(
+      attrValue ? `[${attributeName}="${attrValue}"]` : `[${attributeName}]`
+    );
   }
   return matchingSelectors.length > 0 ? matchingSelectors.join('') : null;
 }
@@ -50,12 +50,13 @@ function getRequiredAttributeSelector(el, compiledAttrs) {
  * Returns the required attribute selector for an element, using the cache when available.
  * @param { Element } el
  * @param { CompiledRequiredAttr[] } compiledAttrs
+ * @param { Function | undefined } filter
  * @param { Map<Element, String|null> | undefined } cache
  * @return { String | null }
  */
-function getCachedRequiredAttr(el, compiledAttrs, cache) {
+function getCachedRequiredAttr(el, compiledAttrs, filter, cache) {
   if (cache && cache.has(el)) return cache.get(el);
-  const selector = getRequiredAttributeSelector(el, compiledAttrs);
+  const selector = getRequiredAttributeSelector(el, compiledAttrs, filter);
   if (cache) cache.set(el, selector);
   return selector;
 }
@@ -271,8 +272,7 @@ function getUniqueSelector( element, selectorTypes, attributesToIgnore, filter )
  * @param {Filter} options.filter Provide a filter function to conditionally reject various traits when building selectors.
  * @param {Map<Element, String>} options.selectorCache Cache for Element -> Selector mappings. Caller is responsible for invalidation.
  * @param {Map<String, Boolean>} options.isUniqueCache Cache for Selector -> isUnique mappings. Caller is responsible for invalidation.
- * @param {Array<{attributeName: string, value: string}>} options.requiredAttributes Attribute patterns that must appear in the generated selector. Each entry specifies an attribute name and a regex pattern to match its value. Matching attributes are woven into the selector chain and ancestor context.
- * @param {Map<Element, String|null>} options.requiredAttributesCache Cache for Element -> required attribute selector mappings. Caller is responsible for invalidation.
+ * @param {{ attributeNames: string[], filter?: Function, elementCache?: Map<Element, String|null> }} options.requiredAttributes Attributes that must appear in the generated selector. Specifies the attribute names to inject, an optional filter function to control which values are allowed, and an optional element cache. Matching attributes are woven into the selector chain and ancestor context.
  * @return {String}
  */
 export default function unique( el, options={} ) {
@@ -283,19 +283,23 @@ export default function unique( el, options={} ) {
     selectorCache,
     isUniqueCache,
     requiredAttributes,
-    requiredAttributesCache,
   } = options;
 
-  // Precompile requiredAttributes regex patterns once per call to avoid
-  // repeated RegExp construction during the element walk.
-  const hasRequiredAttrs = requiredAttributes && requiredAttributes.length > 0;
+  const {
+    attributeNames: requiredAttributeNames,
+    filter: reqFilter,
+    elementCache: reqCache,
+  } = requiredAttributes || {};
+
+  // Precompile required attribute patterns once per call to avoid repeated
+  // RegExp construction during the element walk.
+  const hasRequiredAttrs = requiredAttributeNames && requiredAttributeNames.length > 0;
   const compiledRequiredAttrs = hasRequiredAttrs
-    ? requiredAttributes.map(({ attributeName, value }) => {
+    ? requiredAttributeNames.map((attributeName) => {
         // Escape regex metacharacters: - [ ] / { } ( ) * + ? . \ ^ $ |
         const escaped = attributeName.replace(/[-[\]/{}()*+?.\\^$|]/g, '\\$&');
         return {
           attributeName,
-          regex: (!value || value === '.*') ? null : new RegExp(value),
           // Matches [attrName=  or [attrName]  — used to detect if the attribute is already present in a selector string.
           dedupPattern: new RegExp('\\[' + escaped + '[=\\]]'),
           // Matches [attrName="any-value"] or [attrName] — used to strip an existing attribute bracket before re-appending it.
@@ -328,7 +332,7 @@ export default function unique( el, options={} ) {
 
       // Merge any matching required attributes into the element's selector
       if (hasRequiredAttrs) {
-        const reqAttr = getCachedRequiredAttr(currentElement, compiledRequiredAttrs, requiredAttributesCache);
+        const reqAttr = getCachedRequiredAttr(currentElement, compiledRequiredAttrs, reqFilter, reqCache);
         if (reqAttr) {
           selector = insertRequiredAttrIntoSelector(selector, reqAttr, compiledRequiredAttrs);
         }
@@ -369,7 +373,7 @@ export default function unique( el, options={} ) {
         const ancestorSelectors = [];
         let ancestor = currentElement.parentElement;
         while (ancestor) {
-          const ancestorReqAttr = getCachedRequiredAttr(ancestor, compiledRequiredAttrs, requiredAttributesCache);
+          const ancestorReqAttr = getCachedRequiredAttr(ancestor, compiledRequiredAttrs, reqFilter, reqCache);
           if (ancestorReqAttr) {
             ancestorSelectors.unshift(ancestorReqAttr);
           }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,12 @@
+export function escapeAttributeValue(value) {
+  // Ultra-minimal escaping purely for attribute values that will be used inside quotes
+  // Using `CSS.escape` would create valid but non-minimal strings (escaping things like spaces)
+  // whereas this only escapes absolutely necessary characters for attribute values that
+  // will be used inside quotes.
+  return value
+    .replace(/\\/g, '\\\\') // backslash
+    .replace(/"/g, '\\"') // quote
+    .replace(/\n/g, '\\A ') // newline
+    .replace(/\r/g, '\\D ') // carriage return
+    .replace(/\f/g, '\\C ') // form feed
+}

--- a/test/unique-selector.js
+++ b/test/unique-selector.js
@@ -308,6 +308,99 @@ describe( 'Unique Selector Tests', () =>
     })
   })
   
+  describe('attribute value escaping', () => {
+    it('escapes newline character in data attribute value', () => {
+      // Value contains a real newline (U+000A) — must be escaped as \A  in CSS
+      const el = $( 'body' )[0].ownerDocument.createElement( 'td' );
+      el.setAttribute( 'data-header', 'Tanggal Claim\nDariSampai' );
+      $( 'body' ).append( el );
+      $( 'body' ).append( '<td></td>' ); // sibling to force non-trivial uniqueness
+      const uniqueSelector = unique( el, { selectorTypes: ['data-header', 'nth-child'] } );
+      expect( uniqueSelector ).to.equal( '[data-header="Tanggal Claim\\A DariSampai"]' );
+    });
+
+    it('escapes carriage return character in data attribute value', () => {
+      const el = $( 'body' )[0].ownerDocument.createElement( 'td' );
+      el.setAttribute( 'data-header', 'line1\rline2' );
+      $( 'body' ).append( el );
+      $( 'body' ).append( '<td></td>' );
+      const uniqueSelector = unique( el, { selectorTypes: ['data-header', 'nth-child'] } );
+      expect( uniqueSelector ).to.equal( '[data-header="line1\\D line2"]' );
+    });
+
+    it('escapes backslash in attribute value', () => {
+      const el = $( 'body' )[0].ownerDocument.createElement( 'div' );
+      el.setAttribute( 'data-path', 'foo\\bar' );
+      $( 'body' ).append( el );
+      $( 'body' ).append( '<div></div>' );
+      const uniqueSelector = unique( el, { selectorTypes: ['data-path', 'nth-child'] } );
+      expect( uniqueSelector ).to.equal( '[data-path="foo\\\\bar"]' );
+    });
+
+    it('escapes double quote in attribute value', () => {
+      const el = $( 'body' )[0].ownerDocument.createElement( 'div' );
+      el.setAttribute( 'data-label', 'say "hello"' );
+      $( 'body' ).append( el );
+      $( 'body' ).append( '<div></div>' );
+      const uniqueSelector = unique( el, { selectorTypes: ['data-label', 'nth-child'] } );
+      expect( uniqueSelector ).to.equal( '[data-label="say \\"hello\\""]' );
+    });
+
+    it('escapes newline in name attribute value', () => {
+      const el = $( 'body' )[0].ownerDocument.createElement( 'input' );
+      el.setAttribute( 'name', 'field\nname' );
+      $( 'body' ).append( el );
+      const uniqueSelector = unique( el, { selectorTypes: ['name', 'nth-child'] } );
+      expect( uniqueSelector ).to.equal( '[name="field\\A name"]' );
+    });
+
+    it('escapes newline in standard attribute value', () => {
+      const el = $( 'body' )[0].ownerDocument.createElement( 'div' );
+      el.setAttribute( 'aria-label', 'line one\nline two' );
+      $( 'body' ).append( el );
+      $( 'body' ).append( '<div></div>' );
+      const uniqueSelector = unique( el, { selectorTypes: ['attribute:aria-label', 'nth-child'] } );
+      expect( uniqueSelector ).to.equal( '[aria-label="line one\\A line two"]' );
+    });
+
+    it('escapes newline in requiredAttributes value', () => {
+      // getRequiredAttributeSelector must apply escapeAttributeValue to the raw DOM value
+      const el = $( 'body' )[0].ownerDocument.createElement( 'td' );
+      el.setAttribute( 'data-header', 'Tanggal Claim\nDariSampai' );
+      $( 'body' ).append( el );
+      $( 'body' ).append( '<td></td>' );
+      const result = unique( el, {
+        selectorTypes: ['nth-child'],
+        requiredAttributes: { attributeNames: ['data-header'] }
+      });
+      expect( result ).to.equal( '[data-header="Tanggal Claim\\A DariSampai"]:nth-child(1)' );
+    });
+
+    it('escapes double quote in requiredAttributes value', () => {
+      const el = $( 'body' )[0].ownerDocument.createElement( 'div' );
+      el.setAttribute( 'data-label', 'say "hello"' );
+      $( 'body' ).append( el );
+      $( 'body' ).append( '<div></div>' );
+      const result = unique( el, {
+        selectorTypes: ['nth-child'],
+        requiredAttributes: { attributeNames: ['data-label'] }
+      });
+      expect( result ).to.equal( '[data-label="say \\"hello\\""]:nth-child(1)' );
+    });
+
+    it('escapes backslash in requiredAttributes value', () => {
+      const el = $( 'body' )[0].ownerDocument.createElement( 'div' );
+      el.setAttribute( 'data-path', 'foo\\bar' );
+      $( 'body' ).append( el );
+      $( 'body' ).append( '<div></div>' );
+      const result = unique( el, {
+        selectorTypes: ['nth-child'],
+        requiredAttributes: { attributeNames: ['data-path'] }
+      });
+      expect( result ).to.equal( '[data-path="foo\\\\bar"]:nth-child(1)' );
+    });
+  });
+
   describe('name', () => {
     it( 'with value', () =>
     {
@@ -1050,7 +1143,7 @@ describe( 'Unique Selector Tests', () =>
         }
       });
       // data-foo is still injected as a required attr even though the main filter rejects it
-      expect( result ).to.include( '[data-foo="keep"]' );
+      expect( result ).to.equal( '[data-foo="keep"] #btn' );
     });
 
     describe('selector pattern edge cases', () => {
@@ -1091,8 +1184,22 @@ describe( 'Unique Selector Tests', () =>
           selectorTypes: ['attribute:data-cy-button', 'nth-child'],
           requiredAttributes: { attributeNames: ['data-cy'] }
         });
-        expect( result ).to.include( '[data-cy-button="action"]' );
-        expect( result ).to.include( '[data-cy="parent"]' );
+        expect( result ).to.equal( '[data-cy-button="action"][data-cy="parent"]' );
+      });
+
+      it('stripPattern correctly matches bracket when attribute value contains escaped characters', () => {
+        // When the base selector (from selectorTypes) already contains [data-label="say \"hello\""]
+        // the stripPattern must match the full bracket including the escaped quote inside the value.
+        const el = $( 'body' )[0].ownerDocument.createElement( 'button' );
+        el.setAttribute( 'data-label', 'say "hello"' );
+        $( 'body' ).append( el );
+        $( 'body' ).append( '<button></button>' ); // sibling to prevent uniqueness via tag
+        const result = unique( el, {
+          selectorTypes: ['data-label', 'nth-child'],
+          requiredAttributes: { attributeNames: ['data-label'] }
+        });
+        // data-label should appear exactly once — not duplicated by requiredAttributes injection
+        expect( result ).to.equal( '[data-label="say \\"hello\\""]' );
       });
 
       it('strips only the overlapping required attribute when multiple required attributes are configured', () => {
@@ -1116,8 +1223,7 @@ describe( 'Unique Selector Tests', () =>
           selectorTypes: ['data-cy', 'nth-child'],
           requiredAttributes: { attributeNames: ['data-cy', 'data-test'] }
         });
-        expect( (result.match(/\[data-cy=/g) || []).length ).to.equal( 1 );
-        expect( result ).to.include( '[data-test="primary"]' );
+        expect( result ).to.equal( '[data-cy="submit-btn"][data-test="primary"]' );
       });
     });
   })

--- a/test/unique-selector.js
+++ b/test/unique-selector.js
@@ -493,4 +493,431 @@ describe( 'Unique Selector Tests', () =>
     const uniqueSelector = unique( el );
     expect( uniqueSelector ).to.equal( null );
   })
+
+  describe('requiredAttributes', () => {
+    it('appends required attribute to unique element selector', () => {
+      $( 'body' ).append( '<div class="foo" data-test="Foo"></div>' );
+      const el = $( '.foo' ).get( 0 );
+      const result = unique( el, {
+        requiredAttributes: [{ attributeName: 'data-test', value: '.*' }]
+      });
+      expect( result ).to.equal( '.foo[data-test="Foo"]' );
+    });
+
+    it('includes ancestors with matching required attributes', () => {
+      $( 'body' ).append(
+        '<div data-foo="foo-1"><div data-foo="foo-2"><button id="my-button"></button></div></div>'
+      );
+      const el = $( '#my-button' ).get( 0 );
+      const result = unique( el, {
+        requiredAttributes: [{ attributeName: 'data-foo', value: '.*' }]
+      });
+      expect( result ).to.equal( '[data-foo="foo-1"] [data-foo="foo-2"] #my-button' );
+    });
+
+    it('includes both target and ancestor required attributes', () => {
+      $( 'body' ).append(
+        '<div data-foo="val"><button data-test="btn"></button></div>'
+      );
+      const el = $( 'button' ).get( 0 );
+      const result = unique( el, {
+        requiredAttributes: [
+          { attributeName: 'data-foo', value: '.*' },
+          { attributeName: 'data-test', value: '.*' }
+        ]
+      });
+      expect( result ).to.equal( '[data-foo="val"] button[data-test="btn"]' );
+    });
+
+    it('returns normal selector when no elements match', () => {
+      $( 'body' ).append( '<div class="bar"></div>' );
+      const el = $( '.bar' ).get( 0 );
+      const result = unique( el, {
+        requiredAttributes: [{ attributeName: 'data-test', value: '.*' }]
+      });
+      expect( result ).to.equal( '.bar' );
+    });
+
+    it('applies regex filtering on attribute values', () => {
+      $( 'body' ).append(
+        '<div data-foo="foo-1"><div data-foo="bar-2"><button id="btn"></button></div></div>'
+      );
+      const el = $( '#btn' ).get( 0 );
+      const result = unique( el, {
+        requiredAttributes: [{ attributeName: 'data-foo', value: '^foo' }]
+      });
+      // Only data-foo="foo-1" matches the ^foo regex, not data-foo="bar-2"
+      expect( result ).to.equal( '[data-foo="foo-1"] #btn' );
+    });
+
+    it('matches multiple requiredAttributes entries', () => {
+      $( 'body' ).append(
+        '<div data-section="header"><div data-test="nav"><span id="item"></span></div></div>'
+      );
+      const el = $( '#item' ).get( 0 );
+      const result = unique( el, {
+        requiredAttributes: [
+          { attributeName: 'data-section', value: '.*' },
+          { attributeName: 'data-test', value: '.*' }
+        ]
+      });
+      expect( result ).to.equal( '[data-section="header"] [data-test="nav"] #item' );
+    });
+
+    it('behaves normally with empty requiredAttributes array', () => {
+      $( 'body' ).append( '<div class="baz"></div>' );
+      const el = $( '.baz' ).get( 0 );
+      const result = unique( el, {
+        requiredAttributes: []
+      });
+      expect( result ).to.equal( '.baz' );
+    });
+
+    it('skips intermediate non-matching elements', () => {
+      $( 'body' ).append(
+        '<div data-foo="outer"><div class="middle"><div data-foo="inner"><button id="target"></button></div></div></div>'
+      );
+      const el = $( '#target' ).get( 0 );
+      const result = unique( el, {
+        requiredAttributes: [{ attributeName: 'data-foo', value: '.*' }]
+      });
+      // .middle div should be skipped, using descendant selectors
+      expect( result ).to.equal( '[data-foo="outer"] [data-foo="inner"] #target' );
+    });
+
+    it('inserts required attribute before nth-child in base selector', () => {
+      $( 'body' ).append(
+        '<div><span data-test="a"></span><span data-test="b"></span></div>'
+      );
+      const el = $( 'span' ).get( 0 );
+      const result = unique( el, {
+        requiredAttributes: [{ attributeName: 'data-test', value: '.*' }]
+      });
+      expect( result ).to.equal( '[data-test="a"]:nth-child(1)' );
+    });
+
+    it('decorates required attrs into base selector with child combinators', () => {
+      // Two parallel trees so that .inner and button aren't globally unique
+      $( 'body' ).append(
+        '<div data-test="app">' +
+          '<div class="outer">' +
+            '<div class="inner" data-test="inner-comp">' +
+              '<button>A</button>' +
+            '</div>' +
+          '</div>' +
+          '<div class="outer">' +
+            '<div class="inner">' +
+              '<button>B</button>' +
+            '</div>' +
+          '</div>' +
+        '</div>'
+      );
+      const el = $( 'body' ).find( 'button' ).get( 0 );
+
+      // Without requiredAttributes, verify the base selector uses > combinators
+      const baseResult = unique( el );
+      expect( baseResult ).to.equal( ':nth-child(1) > .inner > button' );
+
+      // With requiredAttributes, data-test should be woven into the > chain
+      // .inner has data-test="inner-comp" and is IN the > chain — attr should be
+      // appended to its segment, not prepended as a separate ancestor.
+      // data-test="app" is ABOVE the chain — prepended with descendant combinator.
+      const result = unique( el, {
+        requiredAttributes: [{ attributeName: 'data-test', value: '.*' }]
+      });
+      expect( result ).to.equal( '[data-test="app"] .inner[data-test="inner-comp"] > button' );
+    });
+
+    it('handles required attrs on multiple elements within the > chain', () => {
+      $( 'body' ).append(
+        '<div data-test="root">' +
+          '<div class="a" data-test="section-a">' +
+            '<div class="b" data-test="panel">' +
+              '<span>X</span>' +
+            '</div>' +
+          '</div>' +
+          '<div class="a" data-test="section-b">' +
+            '<div class="b">' +
+              '<span>Y</span>' +
+            '</div>' +
+          '</div>' +
+        '</div>'
+      );
+      const el = $( 'body' ).find( 'span' ).get( 0 );
+
+      const result = unique( el, {
+        requiredAttributes: [{ attributeName: 'data-test', value: '.*' }]
+      });
+      // data-test="root" is above the chain, data-test="section-a" and
+      // data-test="panel" are elements in the > chain
+      expect( result ).to.equal( '[data-test="root"] [data-test="section-a"] .b[data-test="panel"] > span' );
+    });
+
+    it('uses cache for sibling elements', () => {
+      $( 'body' ).append(
+        '<div data-foo="parent"><span id="a"></span><span id="b"></span></div>'
+      );
+      const cache = new Map();
+      const elA = $( '#a' ).get( 0 );
+      const elB = $( '#b' ).get( 0 );
+      const opts = {
+        requiredAttributes: [{ attributeName: 'data-foo', value: '.*' }],
+        requiredAttributesCache: cache,
+      };
+
+      const resultA = unique( elA, opts );
+      expect( resultA ).to.equal( '[data-foo="parent"] #a' );
+      // Cache should have entries after first call
+      expect( cache.size ).to.be.greaterThan( 0 );
+
+      const resultB = unique( elB, opts );
+      expect( resultB ).to.equal( '[data-foo="parent"] #b' );
+    });
+
+    it('deep nesting (8 levels) with required attrs at levels 1, 3, 6', () => {
+      // Duplicate nav-items force a > chain for uniqueness.
+      // Required attrs at depth 1 (app), 3 (sidebar), 6 (nav-section).
+      $( 'body' ).append(
+        '<div data-cy="app" class="root">' +
+          '<main class="layout">' +
+            '<div data-cy="sidebar" class="panel">' +
+              '<ul class="nav">' +
+                '<li class="nav-item">' +
+                  '<div data-cy="nav-section" class="section">' +
+                    '<div class="item-wrapper">' +
+                      '<a class="link">Link A</a>' +
+                    '</div>' +
+                  '</div>' +
+                '</li>' +
+                '<li class="nav-item">' +
+                  '<div class="section">' +
+                    '<div class="item-wrapper">' +
+                      '<a class="link">Link B</a>' +
+                    '</div>' +
+                  '</div>' +
+                '</li>' +
+              '</ul>' +
+            '</div>' +
+          '</main>' +
+        '</div>'
+      );
+      const el = $( 'body' ).find( 'a.link' ).get( 0 );
+
+      // Base uses nth-child to disambiguate the two nav-items
+      expect( unique( el ) ).to.equal(
+        ':nth-child(1) > .section > .item-wrapper > .link'
+      );
+
+      // data-cy="nav-section" woven into the .section segment of the > chain,
+      // data-cy="app" and data-cy="sidebar" above the chain as ancestors
+      expect( unique( el, {
+        requiredAttributes: [{ attributeName: 'data-cy', value: '.*' }]
+      })).to.equal(
+        '[data-cy="app"] [data-cy="sidebar"] .section[data-cy="nav-section"] > .item-wrapper > .link'
+      );
+    });
+
+    it('sibling subtrees with target having a required attr and duplicates', () => {
+      // Two card subtrees with duplicate structure. Target button has data-test.
+      // Sibling button in same card + button in duplicate card.
+      $( 'body' ).append(
+        '<div id="app">' +
+          '<div data-test="header" class="region">' +
+            '<nav class="nav"><a class="logo">Logo</a></nav>' +
+          '</div>' +
+          '<div data-test="content" class="region">' +
+            '<div class="container">' +
+              '<div data-test="card" class="card">' +
+                '<div class="card-body">' +
+                  '<div class="row">' +
+                    '<div class="col"><button class="btn" data-test="submit">Go</button></div>' +
+                    '<div class="col"><button class="btn">Cancel</button></div>' +
+                  '</div>' +
+                '</div>' +
+              '</div>' +
+              '<div data-test="card" class="card">' +
+                '<div class="card-body">' +
+                  '<div class="row">' +
+                    '<div class="col"><button class="btn" data-test="reset">Reset</button></div>' +
+                  '</div>' +
+                '</div>' +
+              '</div>' +
+            '</div>' +
+          '</div>' +
+        '</div>'
+      );
+      const el = $( 'button[data-test="submit"]' ).get( 0 );
+
+      // Base needs a long > chain to disambiguate through duplicate cards and cols
+      expect( unique( el ) ).to.equal(
+        ':nth-child(1) > .card-body > .row > :nth-child(1) > .btn'
+      );
+
+      // data-test="submit" on target makes it unique early,
+      // data-test="content" and data-test="card" above as ancestors
+      expect( unique( el, {
+        requiredAttributes: [{ attributeName: 'data-test', value: '.*' }]
+      })).to.equal(
+        '[data-test="content"] [data-test="card"] .btn[data-test="submit"]'
+      );
+    });
+
+    it('regex filters out non-matching required attrs at various depths', () => {
+      // data-test values at multiple levels; regex ^page- excludes "internal-layout"
+      $( 'body' ).append(
+        '<div data-test="page-home" class="page">' +
+          '<div data-test="internal-layout" class="layout">' +
+            '<div class="sidebar">' +
+              '<div data-test="page-nav" class="widget">' +
+                '<div class="widget-body">' +
+                  '<ul class="list">' +
+                    '<li class="list-item">' +
+                      '<a class="action" data-test="page-link-1">L1</a>' +
+                    '</li>' +
+                    '<li class="list-item">' +
+                      '<a class="action" data-test="page-link-2">L2</a>' +
+                    '</li>' +
+                  '</ul>' +
+                '</div>' +
+              '</div>' +
+            '</div>' +
+          '</div>' +
+        '</div>'
+      );
+      const el = $( 'a[data-test="page-link-1"]' ).get( 0 );
+
+      expect( unique( el ) ).to.equal( ':nth-child(1) > .action' );
+
+      // "internal-layout" does NOT match ^page-, so it's excluded
+      expect( unique( el, {
+        requiredAttributes: [{ attributeName: 'data-test', value: '^page-' }]
+      })).to.equal(
+        '[data-test="page-home"] [data-test="page-nav"] .action[data-test="page-link-1"]'
+      );
+    });
+
+    it('two requiredAttributes (data-cy + data-region) across 8 levels', () => {
+      // Required attrs from two different attribute names interleaved at different levels.
+      // Duplicate panes force > chain.
+      $( 'body' ).append(
+        '<div data-region="main" class="app">' +
+          '<div data-cy="dashboard">' +
+            '<div class="grid">' +
+              '<div data-region="left" class="pane">' +
+                '<div data-cy="widget-a" class="widget">' +
+                  '<div class="widget-content">' +
+                    '<div class="inner">' +
+                      '<span class="value">42</span>' +
+                    '</div>' +
+                  '</div>' +
+                '</div>' +
+              '</div>' +
+              '<div data-region="right" class="pane">' +
+                '<div class="widget">' +
+                  '<div class="widget-content">' +
+                    '<div class="inner">' +
+                      '<span class="value">99</span>' +
+                    '</div>' +
+                  '</div>' +
+                '</div>' +
+              '</div>' +
+            '</div>' +
+          '</div>' +
+        '</div>'
+      );
+      const el = $( 'span.value' ).get( 0 );
+
+      expect( unique( el ) ).to.equal(
+        ':nth-child(1) > .widget > .widget-content > .inner > .value'
+      );
+
+      // data-cy="widget-a" woven into the .widget segment in the > chain,
+      // data-region="main", data-cy="dashboard", data-region="left" above chain
+      expect( unique( el, {
+        requiredAttributes: [
+          { attributeName: 'data-cy', value: '.*' },
+          { attributeName: 'data-region', value: '.*' }
+        ]
+      })).to.equal(
+        '[data-region="main"] [data-cy="dashboard"] [data-region="left"] .widget[data-cy="widget-a"] > .widget-content > .inner > .value'
+      );
+    });
+
+    it('ID at intermediate level cuts chain short, required attrs above and below', () => {
+      // #main-content makes the chain unique early.
+      // Required attrs exist both above the ID (data-test="app") and below it (data-test="form", "email").
+      $( 'body' ).append(
+        '<div data-test="app">' +
+          '<div class="wrapper">' +
+            '<div id="main-content">' +
+              '<div data-test="form" class="form">' +
+                '<div class="form-group">' +
+                  '<div class="input-row">' +
+                    '<div class="field">' +
+                      '<input type="text" data-test="email" class="input" />' +
+                    '</div>' +
+                    '<div class="field">' +
+                      '<input type="text" class="input" />' +
+                    '</div>' +
+                  '</div>' +
+                '</div>' +
+              '</div>' +
+            '</div>' +
+          '</div>' +
+        '</div>'
+      );
+      const el = $( 'input[data-test="email"]' ).get( 0 );
+
+      // ID makes uniqueness easy — short base chain
+      expect( unique( el ) ).to.equal( ':nth-child(1) > .input' );
+
+      // data-test="email" on target, data-test="form" and data-test="app" as ancestors
+      expect( unique( el, {
+        requiredAttributes: [{ attributeName: 'data-test', value: '.*' }]
+      })).to.equal(
+        '[data-test="app"] [data-test="form"] .input[data-test="email"]'
+      );
+    });
+
+    it('does not duplicate attribute already present via selectorTypes', () => {
+      $( 'body' ).append(
+        '<div data-case="supplemental_identifier_to_deconflict">' +
+          '<form id="autogen_wrapper" data-cy="autogen_shippingAddress">' +
+            '<h4 id="autogen_formTitle">Shipping Address</h4>' +
+            '<label>First Name <input id="autogen_firstName"></label>' +
+            '<label>Last Name <input id="autogen_lastName"></label>' +
+          '</form>' +
+          '<label>Address' +
+            '<div id="mui_wrapper" class="MuiFormControl-root" data-cy="mui-shipping">' +
+              '<textarea id="autogen_address"></textarea>' +
+            '</div>' +
+          '</label>' +
+          '<div class="v-application"><div>' +
+            '<div id="vuetify_wrapper" class="v-input" data-qa="vuetify-shipping">' +
+              '<label>Phone Number <input id="autogen_phone"></label>' +
+            '</div>' +
+          '</div></div>' +
+        '</div>'
+      );
+
+      const el = $( '#autogen_firstName' ).get( 0 );
+      const result = unique( el, {
+        selectorTypes: ['data-cy', 'id', 'class', 'tag', 'nth-child'],
+        requiredAttributes: [{ attributeName: 'data-cy', value: '.*' }]
+      });
+      expect( result ).to.equal( '[data-cy="autogen_shippingAddress"] #autogen_firstName' );
+    });
+
+    it('does not false-match attribute name inside another attribute value', () => {
+      $( 'body' ).append(
+        '<div data-foo="data-cy-blargh" data-cy="real"><span id="falseMatchTarget"></span></div>'
+      );
+      const el = $( '#falseMatchTarget' ).get( 0 );
+      const result = unique( el, {
+        selectorTypes: ['data-foo', 'id', 'class', 'tag', 'nth-child'],
+        requiredAttributes: [{ attributeName: 'data-cy', value: '.*' }]
+      });
+      expect( result ).to.equal( '[data-cy="real"] #falseMatchTarget' );
+    });
+  })
 } );

--- a/test/unique-selector.js
+++ b/test/unique-selector.js
@@ -499,7 +499,7 @@ describe( 'Unique Selector Tests', () =>
       $( 'body' ).append( '<div class="foo" data-test="Foo"></div>' );
       const el = $( '.foo' ).get( 0 );
       const result = unique( el, {
-        requiredAttributes: [{ attributeName: 'data-test', value: '.*' }]
+        requiredAttributes: { attributeNames: ['data-test'] }
       });
       expect( result ).to.equal( '.foo[data-test="Foo"]' );
     });
@@ -510,7 +510,7 @@ describe( 'Unique Selector Tests', () =>
       );
       const el = $( '#my-button' ).get( 0 );
       const result = unique( el, {
-        requiredAttributes: [{ attributeName: 'data-foo', value: '.*' }]
+        requiredAttributes: { attributeNames: ['data-foo'] }
       });
       expect( result ).to.equal( '[data-foo="foo-1"] [data-foo="foo-2"] #my-button' );
     });
@@ -521,10 +521,7 @@ describe( 'Unique Selector Tests', () =>
       );
       const el = $( 'button' ).get( 0 );
       const result = unique( el, {
-        requiredAttributes: [
-          { attributeName: 'data-foo', value: '.*' },
-          { attributeName: 'data-test', value: '.*' }
-        ]
+        requiredAttributes: { attributeNames: ['data-foo', 'data-test'] }
       });
       expect( result ).to.equal( '[data-foo="val"] button[data-test="btn"]' );
     });
@@ -533,42 +530,48 @@ describe( 'Unique Selector Tests', () =>
       $( 'body' ).append( '<div class="bar"></div>' );
       const el = $( '.bar' ).get( 0 );
       const result = unique( el, {
-        requiredAttributes: [{ attributeName: 'data-test', value: '.*' }]
+        requiredAttributes: { attributeNames: ['data-test'] }
       });
       expect( result ).to.equal( '.bar' );
     });
 
-    it('applies regex filtering on attribute values', () => {
+    it('filter function excludes non-matching required attribute values', () => {
       $( 'body' ).append(
         '<div data-foo="foo-1"><div data-foo="bar-2"><button id="btn"></button></div></div>'
       );
       const el = $( '#btn' ).get( 0 );
       const result = unique( el, {
-        requiredAttributes: [{ attributeName: 'data-foo', value: '^foo' }]
+        requiredAttributes: {
+          attributeNames: ['data-foo'],
+          filter: (type, key, value) => {
+            if (type === 'attribute' && key === 'data-foo') return /^foo/.test(value)
+            return true
+          }
+        }
       });
-      // Only data-foo="foo-1" matches the ^foo regex, not data-foo="bar-2"
+      // Only data-foo="foo-1" matches the ^foo filter, not data-foo="bar-2"
       expect( result ).to.equal( '[data-foo="foo-1"] #btn' );
     });
 
-    it('empty value matches any attribute value (treated as match-all)', () => {
+    it('no filter matches any attribute value', () => {
       $( 'body' ).append(
-        '<div data-cy="alpha"><button id="btn-empty-value"></button></div>'
+        '<div data-cy="alpha"><button id="btn-no-filter"></button></div>'
       );
-      const el = $( '#btn-empty-value' ).get( 0 );
+      const el = $( '#btn-no-filter' ).get( 0 );
       const result = unique( el, {
-        requiredAttributes: [{ attributeName: 'data-cy', value: '' }]
+        requiredAttributes: { attributeNames: ['data-cy'] }
       });
-      expect( result ).to.equal( '[data-cy="alpha"] #btn-empty-value' );
+      expect( result ).to.equal( '[data-cy="alpha"] #btn-no-filter' );
     });
 
-    it('value ".*" matches any attribute value without running a regex', () => {
+    it('omitting filter matches any attribute value', () => {
       // Both ancestors carry the attribute with distinct values — both must appear in the selector.
       $( 'body' ).append(
         '<div data-cy="alpha"><div data-cy="beta"><button id="btn-wildcard"></button></div></div>'
       );
       const el = $( '#btn-wildcard' ).get( 0 );
       const result = unique( el, {
-        requiredAttributes: [{ attributeName: 'data-cy', value: '.*' }]
+        requiredAttributes: { attributeNames: ['data-cy'] }
       });
       expect( result ).to.equal( '[data-cy="alpha"] [data-cy="beta"] #btn-wildcard' );
     });
@@ -579,10 +582,7 @@ describe( 'Unique Selector Tests', () =>
       );
       const el = $( '#item' ).get( 0 );
       const result = unique( el, {
-        requiredAttributes: [
-          { attributeName: 'data-section', value: '.*' },
-          { attributeName: 'data-test', value: '.*' }
-        ]
+        requiredAttributes: { attributeNames: ['data-section', 'data-test'] }
       });
       expect( result ).to.equal( '[data-section="header"] [data-test="nav"] #item' );
     });
@@ -591,7 +591,7 @@ describe( 'Unique Selector Tests', () =>
       $( 'body' ).append( '<div class="baz"></div>' );
       const el = $( '.baz' ).get( 0 );
       const result = unique( el, {
-        requiredAttributes: []
+        requiredAttributes: { attributeNames: [] }
       });
       expect( result ).to.equal( '.baz' );
     });
@@ -602,7 +602,7 @@ describe( 'Unique Selector Tests', () =>
       );
       const el = $( '#target' ).get( 0 );
       const result = unique( el, {
-        requiredAttributes: [{ attributeName: 'data-foo', value: '.*' }]
+        requiredAttributes: { attributeNames: ['data-foo'] }
       });
       // .middle div should be skipped, using descendant selectors
       expect( result ).to.equal( '[data-foo="outer"] [data-foo="inner"] #target' );
@@ -614,7 +614,7 @@ describe( 'Unique Selector Tests', () =>
       );
       const el = $( 'span' ).get( 0 );
       const result = unique( el, {
-        requiredAttributes: [{ attributeName: 'data-test', value: '.*' }]
+        requiredAttributes: { attributeNames: ['data-test'] }
       });
       expect( result ).to.equal( '[data-test="a"]:nth-child(1)' );
     });
@@ -646,7 +646,7 @@ describe( 'Unique Selector Tests', () =>
       // appended to its segment, not prepended as a separate ancestor.
       // data-test="app" is ABOVE the chain — prepended with descendant combinator.
       const result = unique( el, {
-        requiredAttributes: [{ attributeName: 'data-test', value: '.*' }]
+        requiredAttributes: { attributeNames: ['data-test'] }
       });
       expect( result ).to.equal( '[data-test="app"] .inner[data-test="inner-comp"] > button' );
     });
@@ -669,7 +669,7 @@ describe( 'Unique Selector Tests', () =>
       const el = $( 'body' ).find( 'span' ).get( 0 );
 
       const result = unique( el, {
-        requiredAttributes: [{ attributeName: 'data-test', value: '.*' }]
+        requiredAttributes: { attributeNames: ['data-test'] }
       });
       // data-test="root" is above the chain, data-test="section-a" and
       // data-test="panel" are elements in the > chain
@@ -684,8 +684,10 @@ describe( 'Unique Selector Tests', () =>
       const elA = $( '#a' ).get( 0 );
       const elB = $( '#b' ).get( 0 );
       const opts = {
-        requiredAttributes: [{ attributeName: 'data-foo', value: '.*' }],
-        requiredAttributesCache: cache,
+        requiredAttributes: {
+          attributeNames: ['data-foo'],
+          elementCache: cache,
+        }
       };
 
       const resultA = unique( elA, opts );
@@ -734,7 +736,7 @@ describe( 'Unique Selector Tests', () =>
       // data-cy="nav-section" woven into the .section segment of the > chain,
       // data-cy="app" and data-cy="sidebar" above the chain as ancestors
       expect( unique( el, {
-        requiredAttributes: [{ attributeName: 'data-cy', value: '.*' }]
+        requiredAttributes: { attributeNames: ['data-cy'] }
       })).to.equal(
         '[data-cy="app"] [data-cy="sidebar"] .section[data-cy="nav-section"] > .item-wrapper > .link'
       );
@@ -779,14 +781,14 @@ describe( 'Unique Selector Tests', () =>
       // data-test="submit" on target makes it unique early,
       // data-test="content" and data-test="card" above as ancestors
       expect( unique( el, {
-        requiredAttributes: [{ attributeName: 'data-test', value: '.*' }]
+        requiredAttributes: { attributeNames: ['data-test'] }
       })).to.equal(
         '[data-test="content"] [data-test="card"] .btn[data-test="submit"]'
       );
     });
 
-    it('regex filters out non-matching required attrs at various depths', () => {
-      // data-test values at multiple levels; regex ^page- excludes "internal-layout"
+    it('filter function excludes non-matching required attribute values at multiple depths', () => {
+      // data-test values at multiple levels; filter excludes "internal-layout"
       $( 'body' ).append(
         '<div data-test="page-home" class="page">' +
           '<div data-test="internal-layout" class="layout">' +
@@ -811,9 +813,15 @@ describe( 'Unique Selector Tests', () =>
 
       expect( unique( el ) ).to.equal( ':nth-child(1) > .action' );
 
-      // "internal-layout" does NOT match ^page-, so it's excluded
+      // "internal-layout" does NOT match the ^page- filter, so it's excluded
       expect( unique( el, {
-        requiredAttributes: [{ attributeName: 'data-test', value: '^page-' }]
+        requiredAttributes: {
+          attributeNames: ['data-test'],
+          filter: (type, key, value) => {
+            if (type === 'attribute' && key === 'data-test') return /^page-/.test(value)
+            return true
+          }
+        }
       })).to.equal(
         '[data-test="page-home"] [data-test="page-nav"] .action[data-test="page-link-1"]'
       );
@@ -857,10 +865,7 @@ describe( 'Unique Selector Tests', () =>
       // data-cy="widget-a" woven into the .widget segment in the > chain,
       // data-region="main", data-cy="dashboard", data-region="left" above chain
       expect( unique( el, {
-        requiredAttributes: [
-          { attributeName: 'data-cy', value: '.*' },
-          { attributeName: 'data-region', value: '.*' }
-        ]
+        requiredAttributes: { attributeNames: ['data-cy', 'data-region'] }
       })).to.equal(
         '[data-region="main"] [data-cy="dashboard"] [data-region="left"] .widget[data-cy="widget-a"] > .widget-content > .inner > .value'
       );
@@ -896,7 +901,7 @@ describe( 'Unique Selector Tests', () =>
 
       // data-test="email" on target, data-test="form" and data-test="app" as ancestors
       expect( unique( el, {
-        requiredAttributes: [{ attributeName: 'data-test', value: '.*' }]
+        requiredAttributes: { attributeNames: ['data-test'] }
       })).to.equal(
         '[data-test="app"] [data-test="form"] .input[data-test="email"]'
       );
@@ -928,7 +933,7 @@ describe( 'Unique Selector Tests', () =>
       const el = $( '#autogen_firstName' ).get( 0 );
       const result = unique( el, {
         selectorTypes: ['data-cy', 'id', 'class', 'tag', 'nth-child'],
-        requiredAttributes: [{ attributeName: 'data-cy', value: '.*' }]
+        requiredAttributes: { attributeNames: ['data-cy'] }
       });
       expect( result ).to.equal( '[data-cy="autogen_shippingAddress"] #autogen_firstName' );
     });
@@ -942,7 +947,7 @@ describe( 'Unique Selector Tests', () =>
       const el = $( '#falseMatchTarget' ).get( 0 );
       const result = unique( el, {
         selectorTypes: ['data-foo', 'id', 'class', 'tag', 'nth-child'],
-        requiredAttributes: [{ attributeName: 'data-cy', value: '.*' }]
+        requiredAttributes: { attributeNames: ['data-cy'] }
       });
       expect( result ).to.equal( '[data-cy="real"] #falseMatchTarget' );
     });
@@ -953,7 +958,7 @@ describe( 'Unique Selector Tests', () =>
       );
       const el = $( '#idTarget' ).get( 0 );
       const result = unique( el, {
-        requiredAttributes: [{ attributeName: 'data-cy', value: '.*' }]
+        requiredAttributes: { attributeNames: ['data-cy'] }
       });
       expect( result ).to.equal( '#idTarget[data-cy="hero"]' );
     });
@@ -964,7 +969,7 @@ describe( 'Unique Selector Tests', () =>
       );
       const el = $( '[name="email"]' ).get( 0 );
       const result = unique( el, {
-        requiredAttributes: [{ attributeName: 'data-cy', value: '.*' }]
+        requiredAttributes: { attributeNames: ['data-cy'] }
       });
       expect( result ).to.equal( '[name="email"][data-cy="emailField"]' );
     });
@@ -976,7 +981,7 @@ describe( 'Unique Selector Tests', () =>
       );
       const el = $( '.foo.bar' ).get( 0 );
       const result = unique( el, {
-        requiredAttributes: [{ attributeName: 'data-cy', value: '.*' }]
+        requiredAttributes: { attributeNames: ['data-cy'] }
       });
       expect( result ).to.equal( '.bar[data-cy="combo"]' );
     });
@@ -988,7 +993,7 @@ describe( 'Unique Selector Tests', () =>
       );
       const el = $( 'div.item' ).get( 0 );
       const result = unique( el, {
-        requiredAttributes: [{ attributeName: 'data-cy', value: '.*' }]
+        requiredAttributes: { attributeNames: ['data-cy'] }
       });
       expect( result ).to.equal( 'div.item[data-cy="divItem"]' );
     });
@@ -1000,7 +1005,7 @@ describe( 'Unique Selector Tests', () =>
       );
       const el = $( 'body' ).find( 'span' ).get( 0 );
       const result = unique( el, {
-        requiredAttributes: [{ attributeName: 'data-cy', value: '.*' }]
+        requiredAttributes: { attributeNames: ['data-cy'] }
       });
       expect( result ).to.equal( '[data-cy="first"]:nth-child(1)' );
     });
@@ -1012,10 +1017,7 @@ describe( 'Unique Selector Tests', () =>
       );
       const el = $( 'body' ).find( 'button' ).get( 0 );
       const result = unique( el, {
-        requiredAttributes: [
-          { attributeName: 'data-cy', value: '.*' },
-          { attributeName: 'data-test', value: '.*' }
-        ]
+        requiredAttributes: { attributeNames: ['data-cy', 'data-test'] }
       });
       expect( result ).to.equal( '[data-cy="submit"][data-test="primary"]:nth-child(1)' );
     });
@@ -1028,9 +1030,95 @@ describe( 'Unique Selector Tests', () =>
       const el = $( 'body' ).find( 'my-component' ).get( 0 );
       const result = unique( el, {
         selectorTypes: ['id', 'class', 'tag', 'nth-child'],
-        requiredAttributes: [{ attributeName: 'data-cy', value: '.*' }]
+        requiredAttributes: { attributeNames: ['data-cy'] }
       });
       expect( result ).to.equal( '[data-cy="widget"]:nth-child(1)' );
+    });
+
+    it('requiredAttributes.filter is independent of the main filter option', () => {
+      // Main filter rejects data-foo entirely for uniqueness purposes.
+      // requiredAttributes.filter allows it — so it still gets injected.
+      $( 'body' ).append(
+        '<div data-foo="keep"><button id="btn"></button></div>'
+      );
+      const el = $( '#btn' ).get( 0 );
+      const result = unique( el, {
+        filter: (type, key) => key !== 'data-foo',  // main filter rejects data-foo for uniqueness
+        requiredAttributes: {
+          attributeNames: ['data-foo'],
+          // no requiredAttributes.filter — all values pass injection
+        }
+      });
+      // data-foo is still injected as a required attr even though the main filter rejects it
+      expect( result ).to.include( '[data-foo="keep"]' );
+    });
+
+    describe('selector pattern edge cases', () => {
+      it('dedupPattern detects valueless [attr] bracket and prevents duplication', () => {
+        // dedupPattern uses character class [=\]] to match either `=` (for [attr="val"])
+        // or `]` (for [attr] with no value). This test exercises the `]` branch:
+        // if `\]` were absent from the class, the valueless form would not be recognised
+        // and the attribute would appear twice in the output.
+        $( 'body' ).append(
+          '<div><span contenteditable></span><span contenteditable></span></div>'
+        );
+        const el = $( 'span' ).get( 0 );
+        // attribute:contenteditable selectorType produces [contenteditable] in the base
+        // selector because the attribute has no value. requiredAttributes must not
+        // append a second [contenteditable].
+        const result = unique( el, {
+          selectorTypes: ['attribute:contenteditable', 'nth-child'],
+          requiredAttributes: { attributeNames: ['contenteditable'] }
+        });
+        const occurrences = (result.match(/\[contenteditable/g) || []).length;
+        expect( occurrences ).to.equal( 1 );
+      });
+
+      it('stripPattern does not strip an attribute whose name is a prefix of the required attribute name', () => {
+        // stripPattern ends with \] so it only matches [data-cy="val"] or [data-cy],
+        // not [data-cy-button="val"] where an extra `-button` follows `data-cy`.
+        // If the terminal \] anchor were absent the strip would consume too much of
+        // the selector, losing the longer attribute.
+        const el = $( 'body' )[0].ownerDocument.createElement( 'div' );
+        el.setAttribute( 'data-cy', 'parent' );
+        el.setAttribute( 'data-cy-button', 'action' );
+        $( 'body' ).append( el );
+        $( 'body' ).append( '<div></div>' ); // sibling to prevent uniqueness via tag alone
+
+        // selectorTypes picks up data-cy-button → base selector is [data-cy-button="action"]
+        // requiredAttributes adds data-cy — its stripPattern must not eat [data-cy-button="action"]
+        const result = unique( el, {
+          selectorTypes: ['attribute:data-cy-button', 'nth-child'],
+          requiredAttributes: { attributeNames: ['data-cy'] }
+        });
+        expect( result ).to.include( '[data-cy-button="action"]' );
+        expect( result ).to.include( '[data-cy="parent"]' );
+      });
+
+      it('strips only the overlapping required attribute when multiple required attributes are configured', () => {
+        // When two required attributes are configured and the base selector (from selectorTypes)
+        // already contains one of them, only that one should be stripped from toInsert.
+        // The other required attribute must still be appended — this exercises the strip loop
+        // iterating over each CompiledRequiredAttr entry independently.
+        $( 'body' ).append(
+          '<div>' +
+            '<button data-cy="submit-btn" data-test="primary">Go</button>' +
+            '<button data-cy="cancel-btn">No</button>' +
+          '</div>'
+        );
+        const el = $( 'button[data-test="primary"]' ).get( 0 );
+
+        // data-cy selectorType produces [data-cy="submit-btn"] as the unique base selector.
+        // toInsert from requiredAttributes is [data-cy="submit-btn"][data-test="primary"].
+        // The strip loop should remove the data-cy bracket (already in base) but leave
+        // data-test — so the final selector contains each attribute exactly once.
+        const result = unique( el, {
+          selectorTypes: ['data-cy', 'nth-child'],
+          requiredAttributes: { attributeNames: ['data-cy', 'data-test'] }
+        });
+        expect( (result.match(/\[data-cy=/g) || []).length ).to.equal( 1 );
+        expect( result ).to.include( '[data-test="primary"]' );
+      });
     });
   })
 } );

--- a/test/unique-selector.js
+++ b/test/unique-selector.js
@@ -588,6 +588,35 @@ describe( 'Unique Selector Tests', () =>
   })
 
   describe('requiredAttributes', () => {
+      it('dedupPattern matches base selector attribute name case-insensitively', () => {
+        // selectorTypes produces [data-Test="Bar"] (mixed case preserved from selectorType string).
+        // requiredAttributes normalises 'DATA-TEST' to 'data-test', but dedupPattern uses /i so
+        // it still recognises [data-Test= in the base selector and prevents duplication.
+        $( 'body' ).append( '<div class="foo" data-test="Bar"></div>' );
+        $( 'body' ).append( '<div class="foo2"></div>' ); // sibling to prevent tag uniqueness
+        const el = $( '.foo' ).get( 0 );
+        const result = unique( el, {
+          selectorTypes: ['data-Test', 'id', 'class', 'tag', 'nth-child'],
+          requiredAttributes: { attributeNames: ['DATA-TEST'] }
+        });
+        // data-test should appear exactly once despite the case mismatch
+        expect( result ).to.equal( '[data-Test="Bar"]' );
+      });
+
+      it('dedup still works when attributeNames case differs from selectorTypes case', () => {
+        // dedupPattern is case-insensitive, so it detects the attribute already in the base
+        // selector regardless of how attributeNames was cased. The required attribute is stripped
+        // from injection, and the base selector string is returned as-is.
+        $( 'body' ).append( '<div class="foo" data-test="Bar"></div>' );
+        const el = $( '.foo' ).get( 0 );
+        const result = unique( el, {
+          selectorTypes: ['data-test', 'id', 'class', 'tag', 'nth-child'],
+          requiredAttributes: { attributeNames: ['DATA-TEST'] }
+        });
+        // data-test appears exactly once — injection was suppressed by the case-insensitive dedup
+        expect( result ).to.equal( '[data-test="Bar"]' );
+      });
+
     it('appends required attribute to unique element selector', () => {
       $( 'body' ).append( '<div class="foo" data-test="Foo"></div>' );
       const el = $( '.foo' ).get( 0 );

--- a/test/unique-selector.js
+++ b/test/unique-selector.js
@@ -550,6 +550,29 @@ describe( 'Unique Selector Tests', () =>
       expect( result ).to.equal( '[data-foo="foo-1"] #btn' );
     });
 
+    it('empty value matches any attribute value (treated as match-all)', () => {
+      $( 'body' ).append(
+        '<div data-cy="alpha"><button id="btn-empty-value"></button></div>'
+      );
+      const el = $( '#btn-empty-value' ).get( 0 );
+      const result = unique( el, {
+        requiredAttributes: [{ attributeName: 'data-cy', value: '' }]
+      });
+      expect( result ).to.equal( '[data-cy="alpha"] #btn-empty-value' );
+    });
+
+    it('value ".*" matches any attribute value without running a regex', () => {
+      // Both ancestors carry the attribute with distinct values — both must appear in the selector.
+      $( 'body' ).append(
+        '<div data-cy="alpha"><div data-cy="beta"><button id="btn-wildcard"></button></div></div>'
+      );
+      const el = $( '#btn-wildcard' ).get( 0 );
+      const result = unique( el, {
+        requiredAttributes: [{ attributeName: 'data-cy', value: '.*' }]
+      });
+      expect( result ).to.equal( '[data-cy="alpha"] [data-cy="beta"] #btn-wildcard' );
+    });
+
     it('matches multiple requiredAttributes entries', () => {
       $( 'body' ).append(
         '<div data-section="header"><div data-test="nav"><span id="item"></span></div></div>'

--- a/test/unique-selector.js
+++ b/test/unique-selector.js
@@ -879,7 +879,9 @@ describe( 'Unique Selector Tests', () =>
       );
     });
 
-    it('does not duplicate attribute already present via selectorTypes', () => {
+    it('deduplicates when same attribute is in both selectorTypes and requiredAttributes', () => {
+      // When selectorTypes includes data-cy, the base selector already contains
+      // [data-cy="..."]. requiredAttributes should not append it again.
       $( 'body' ).append(
         '<div data-case="supplemental_identifier_to_deconflict">' +
           '<form id="autogen_wrapper" data-cy="autogen_shippingAddress">' +
@@ -908,7 +910,9 @@ describe( 'Unique Selector Tests', () =>
       expect( result ).to.equal( '[data-cy="autogen_shippingAddress"] #autogen_firstName' );
     });
 
-    it('does not false-match attribute name inside another attribute value', () => {
+    it('dedup check does not false-match attribute name inside another attribute value', () => {
+      // data-foo's value contains "data-cy" as a substring — the dedup check
+      // should only match actual [data-cy=...] attribute selectors, not values.
       $( 'body' ).append(
         '<div data-foo="data-cy-blargh" data-cy="real"><span id="falseMatchTarget"></span></div>'
       );
@@ -918,6 +922,92 @@ describe( 'Unique Selector Tests', () =>
         requiredAttributes: [{ attributeName: 'data-cy', value: '.*' }]
       });
       expect( result ).to.equal( '[data-cy="real"] #falseMatchTarget' );
+    });
+
+    it('merges required attr with ID base selector', () => {
+      $( 'body' ).append(
+        '<div><span id="idTarget" data-cy="hero"></span><span></span></div>'
+      );
+      const el = $( '#idTarget' ).get( 0 );
+      const result = unique( el, {
+        requiredAttributes: [{ attributeName: 'data-cy', value: '.*' }]
+      });
+      expect( result ).to.equal( '#idTarget[data-cy="hero"]' );
+    });
+
+    it('merges required attr with name base selector', () => {
+      $( 'body' ).append(
+        '<div><input name="email" data-cy="emailField"></div>'
+      );
+      const el = $( '[name="email"]' ).get( 0 );
+      const result = unique( el, {
+        requiredAttributes: [{ attributeName: 'data-cy', value: '.*' }]
+      });
+      expect( result ).to.equal( '[name="email"][data-cy="emailField"]' );
+    });
+
+    it('merges required attr with multi-class base selector', () => {
+      // Two elements share .foo, but only one has .bar — combo .foo.bar is unique
+      $( 'body' ).append(
+        '<div><span class="foo bar" data-cy="combo"></span><span class="foo"></span></div>'
+      );
+      const el = $( '.foo.bar' ).get( 0 );
+      const result = unique( el, {
+        requiredAttributes: [{ attributeName: 'data-cy', value: '.*' }]
+      });
+      expect( result ).to.equal( '.bar[data-cy="combo"]' );
+    });
+
+    it('merges required attr with tag+class combo base selector', () => {
+      // Two .item elements (span and div) — tag+class combo div.item is unique
+      $( 'body' ).append(
+        '<div><div class="item" data-cy="divItem">A</div><span class="item">B</span></div>'
+      );
+      const el = $( 'div.item' ).get( 0 );
+      const result = unique( el, {
+        requiredAttributes: [{ attributeName: 'data-cy', value: '.*' }]
+      });
+      expect( result ).to.equal( 'div.item[data-cy="divItem"]' );
+    });
+
+    it('merges required attr with tag:nth-child base selector', () => {
+      // Two spans, neither has a unique class/id — falls through to nth-child
+      $( 'body' ).append(
+        '<div><span data-cy="first">A</span><span>B</span></div>'
+      );
+      const el = $( 'body' ).find( 'span' ).get( 0 );
+      const result = unique( el, {
+        requiredAttributes: [{ attributeName: 'data-cy', value: '.*' }]
+      });
+      expect( result ).to.equal( '[data-cy="first"]:nth-child(1)' );
+    });
+
+    it('merges multiple required attrs into a single element selector', () => {
+      // Both data-cy and data-test should be woven into the same element's selector
+      $( 'body' ).append(
+        '<div><button class="btn" data-cy="submit" data-test="primary">Go</button><button class="btn">Cancel</button></div>'
+      );
+      const el = $( 'body' ).find( 'button' ).get( 0 );
+      const result = unique( el, {
+        requiredAttributes: [
+          { attributeName: 'data-cy', value: '.*' },
+          { attributeName: 'data-test', value: '.*' }
+        ]
+      });
+      expect( result ).to.equal( '[data-cy="submit"][data-test="primary"]:nth-child(1)' );
+    });
+
+    it('merges required attr with nth-child fallback base selector', () => {
+      // Custom elements with no id/class/name — falls through to nth-child
+      $( 'body' ).append(
+        '<div><my-component data-cy="widget"></my-component><my-component></my-component></div>'
+      );
+      const el = $( 'body' ).find( 'my-component' ).get( 0 );
+      const result = unique( el, {
+        selectorTypes: ['id', 'class', 'tag', 'nth-child'],
+        requiredAttributes: [{ attributeName: 'data-cy', value: '.*' }]
+      });
+      expect( result ).to.equal( '[data-cy="widget"]:nth-child(1)' );
     });
   })
 } );


### PR DESCRIPTION
## Summary

Adds a `requiredAttributes` option to `unique()` that ensures specified data attributes (e.g. `data-cy`, `data-test`) appear in generated selectors, even when the element is already uniquely identifiable without them. This is useful for container/"component" identification, where selectors should include meaningful attributes for readability and stability.

### How it works

- **In-chain decoration**: As the selector chain is built walking up from the target element, each element's selector is checked for matching required attributes and they are merged in (before any `:nth-child` pseudo-class).
- **Ancestor context**: Once a unique chain is found, ancestors above it are walked to collect additional required attribute selectors, which are prepended using descendant combinators (e.g. `[data-cy="app"] [data-cy="nav"] .btn`).
- **Deduplication**: When the same attribute appears in both `selectorTypes` and `requiredAttributes`, the merge step detects the existing attribute selector and skips it — using a regex that matches the actual `[attr=` bracket position, not substrings inside quoted values.
- **Precompiled patterns**: All regex patterns (value matching, dedup detection, and stripping) are compiled once per `unique()` call rather than per-element during the walk.
- **Caching**: A `requiredAttributesCache` (Map<Element, string|null>) can be provided to avoid redundant attribute lookups across repeated calls. The `selectorCache` stores the fully decorated selector so cache hits return the final value without re-decoration.

### New options

- **`requiredAttributes`** (`Array<{attributeName: string, value: string}>`) — Attribute patterns to include in selectors. `value` is a regex pattern tested against the attribute's value.
- **`requiredAttributesCache`** (`Map<Element, String|null>`) — Optional cache for required attribute lookups. Caller manages invalidation.

## Test plan

27 `requiredAttributes` tests covering:

- **Basic merging** — required attr appended to class, tag, ID, name, multi-class, tag+class combo, and nth-child base selectors
- **Multiple required attrs** — two attributes merged into a single element's selector
- **Ancestor context** — ancestors with matching attrs prepended via descendant combinators; intermediate non-matching elements skipped
- **Chain decoration** — required attrs woven into `>` chain segments (not prepended as separate ancestors)
- **Regex filtering** — only attribute values matching the regex pattern are included
- **Deduplication** — no duplicate when same attribute is in `selectorTypes` and `requiredAttributes`; dedup check doesn't false-match attribute names appearing inside other attributes' values
- **Caching** — `requiredAttributesCache` is populated and reused across sibling calls
- **Empty/no-match** — empty `requiredAttributes` array and no matching elements behave like baseline
- **Deep nesting** — 8-level DOMs with attrs at various depths, multiple attribute names interleaved
- **Performance benchmarks** (separate file) — 4 permutations validated for correctness and timed across 1000 runs on both unique-attr and repeated-attr DOMs